### PR TITLE
Add Stop Sequence Processing Functionality 添加停止序列处理功能

### DIFF
--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -30,6 +30,7 @@ pub async fn api_messages(
     print_out_json(&p, "client_req.json");
     state.api_format = f.api_format;
     state.stream = stream;
+    state.current_request = Some(p.clone());
     let format_display = match f.api_format {
         ApiFormat::Claude => f.api_format.to_string().green(),
         ApiFormat::OpenAI => f.api_format.to_string().yellow(),

--- a/src/body/response.rs
+++ b/src/body/response.rs
@@ -88,10 +88,17 @@ impl RequestContext {
             let stream = input.eventsource();
             let text = merge_sse(stream).await;
             print_out_text(&text, "non_stream.txt");
-            return Json(Message::from(text)).into_response();
+            let mut resp = Json(Message::from(text)).into_response();
+            // Add RequestContext to response extensions
+            resp.extensions_mut().insert(self.clone());
+            return resp;
         }
 
         // stream the response
-        Body::from_stream(input).into_response()
+        let mut resp = Body::from_stream(input).into_response();
+        // Add RequestContext to response 
+        
+        resp.extensions_mut().insert(self.clone());
+        resp
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     config::{CLEWDR_CONFIG, CookieStatus, ENDPOINT, Reason},
     error::ClewdrError,
     services::cookie_manager::CookieEventSender,
+    types::message::CreateMessageParams,
 };
 
 pub mod bootstrap;
@@ -35,6 +36,7 @@ pub struct RequestContext {
     pub stream: bool,
     pub client: Client,
     pub key: Option<(u64, usize)>,
+    pub current_request: Option<CreateMessageParams>,
 }
 
 impl RequestContext {
@@ -53,6 +55,7 @@ impl RequestContext {
             stream: false,
             client: SUPER_CLIENT.to_owned(),
             key: None,
+            current_request: None,
         }
     }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -6,10 +6,13 @@
 /// - Authentication: Verify API keys for different authentication methods (admin, OpenAI, Claude)
 /// - Request preprocessing: Normalize requests from different API formats
 /// - Response transformation: Convert between different response formats and handle streaming
+/// - Stop sequence handling: Process stop sequences in streaming responses
 mod auth;
 mod request;
 mod response;
+mod stop_sequence;
 
 pub use auth::{RequireAdminAuth, RequireClaudeAuth, RequireOaiAuth};
 pub use request::{FormatInfo, Preprocess};
 pub use response::transform_oai_response;
+pub use stop_sequence::handle_stop_sequences;

--- a/src/middleware/stop_sequence.rs
+++ b/src/middleware/stop_sequence.rs
@@ -1,0 +1,297 @@
+use axum::response::{IntoResponse, Response, Sse};
+use eventsource_stream::{Event as EventSourceEvent, Eventsource};
+use futures::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tracing::{debug, info};
+
+use crate::{
+    context::RequestContext,
+    types::message::{MessageDeltaContent, StopReason, StreamEvent, StreamUsage},
+    utils::stop_sequence::StopSequenceMatcher,
+};
+
+use super::FormatInfo;
+
+/// Middleware for handling stop sequences in streaming responses
+///
+/// This middleware intercepts streaming responses and checks for stop sequences.
+/// When a stop sequence is detected, it:
+/// 1. Sends any remaining text before the stop sequence
+/// 2. Sends appropriate stop events based on the API format
+/// 3. Terminates the stream
+///
+/// # Arguments
+/// * `resp` - The original response to be processed
+///
+/// # Returns
+/// The original or transformed response with stop sequence handling
+pub async fn handle_stop_sequences(resp: Response) -> impl IntoResponse {
+    // Get format info and request context from response extensions
+    let stop_sequences = {
+        // Get format info
+        let Some(format_info) = resp.extensions().get::<FormatInfo>() else {
+            return resp;
+        };
+
+        // Only process streaming responses with 200 status
+        if !format_info.stream || resp.status() != 200 {
+            return resp;
+        }
+
+        // Get request context
+        let Some(ctx) = resp.extensions().get::<RequestContext>() else {
+            return resp;
+        };
+
+        // Check if stop_sequences are present in the request
+        let Some(stop_sequences) = ctx
+            .current_request
+            .as_ref()
+            .and_then(|req| req.stop_sequences.clone())
+        else {
+            return resp;
+        };
+
+        // If no stop sequences are defined, return the original response
+        if stop_sequences.is_empty() {
+            return resp;
+        }
+
+        stop_sequences
+    };
+
+    debug!(
+        "Stop sequences middleware active with: {:?}",
+        stop_sequences
+    );
+
+    // Create a stop sequence matcher
+    let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+    // Get the response body as a stream
+    let body = resp.into_body();
+    let stream = body.into_data_stream();
+
+    // Create a stream transformer that checks for stop sequences
+    let stream = StopSequenceStream {
+        inner: stream.eventsource(),
+        matcher,
+        stopped: false,
+        stop_event_state: 0,
+        stop_events: None,
+    };
+
+    // Return the transformed stream as a response
+    Sse::new(stream)
+        .keep_alive(Default::default())
+        .into_response()
+}
+
+/// Stream transformer that checks for stop sequences
+struct StopSequenceStream<S> {
+    inner: S,
+    matcher: StopSequenceMatcher,
+    stopped: bool,
+    stop_event_state: u8,
+    stop_events: Option<(
+        axum::response::sse::Event,
+        axum::response::sse::Event,
+        axum::response::sse::Event,
+    )>,
+}
+
+impl<S, E> Stream for StopSequenceStream<S>
+where
+    S: Stream<Item = Result<EventSourceEvent, E>> + Unpin,
+    E: std::error::Error + 'static,
+{
+    type Item = Result<axum::response::sse::Event, E>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // If we have stop events to send, send them in sequence
+        if self.stopped {
+            // We've already matched a stop sequence and need to send the remaining events
+            // Clone the event we need to send based on the current state
+            let event_to_send = match self.stop_event_state {
+                0 => {
+                    // Get content_block_stop event
+                    if let Some((content_block_stop, _, _)) = &self.stop_events {
+                        let event = content_block_stop.clone();
+                        Some(event)
+                    } else {
+                        None
+                    }
+                }
+                1 => {
+                    // Get message_delta event
+                    if let Some((_, message_delta, _)) = &self.stop_events {
+                        let event = message_delta.clone();
+                        Some(event)
+                    } else {
+                        None
+                    }
+                }
+                2 => {
+                    // Get message_stop event
+                    if let Some((_, _, message_stop)) = &self.stop_events {
+                        let event = message_stop.clone();
+                        Some(event)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+
+            // If we have an event to send, return it and increment the state
+            if let Some(event) = event_to_send {
+                self.stop_event_state += 1;
+                return Poll::Ready(Some(Ok(event)));
+            } else {
+                return Poll::Ready(None);
+            }
+        }
+
+        // Poll the inner stream
+        match Pin::new(&mut self.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(event))) => {
+                // Process the event data
+                let event_data = event.data.clone();
+
+                // Try to parse the event as a StreamEvent
+                if let Ok(stream_event) = serde_json::from_str::<StreamEvent>(&event_data) {
+                    // Handle different event types
+                    match stream_event {
+                        StreamEvent::ContentBlockDelta { index, delta } => {
+                            // Extract text from the delta
+                            let text = match delta {
+                                crate::types::message::ContentBlockDelta::TextDelta { text } => {
+                                    text
+                                }
+                                _ => return Poll::Ready(Some(Ok(convert_event(event)))),
+                            };
+
+                            // Check if the text contains a stop sequence
+                            let (output, matched) = self.matcher.process(&text);
+
+                            if let Some(stop_sequence) = matched {
+                                info!("Stop sequence matched: {}", stop_sequence);
+
+                                // Set stopped flag to true
+                                self.stopped = true;
+
+                                // Create content_block_stop event
+                                let content_block_stop = StreamEvent::ContentBlockStop { index };
+                                let content_block_stop_event =
+                                    axum::response::sse::Event::default()
+                                        .event("content_block_stop")
+                                        .json_data(&content_block_stop)
+                                        .unwrap();
+
+                                // Create message_delta event with stop_reason and stop_sequence
+                                let message_delta = StreamEvent::MessageDelta {
+                                    delta: MessageDeltaContent {
+                                        stop_reason: Some(StopReason::StopSequence),
+                                        stop_sequence: Some(stop_sequence),
+                                    },
+                                    usage: Some(StreamUsage {
+                                        input_tokens: 0,
+                                        output_tokens: 0,
+                                    }),
+                                };
+                                let delta_event = axum::response::sse::Event::default()
+                                    .event("message_delta")
+                                    .json_data(&message_delta)
+                                    .unwrap();
+
+                                // Create message_stop event
+                                let message_stop = StreamEvent::MessageStop;
+                                let stop_message_event = axum::response::sse::Event::default()
+                                    .event("message_stop")
+                                    .json_data(&message_stop)
+                                    .unwrap();
+
+                                // Store all stop events for sequential sending
+                                self.stop_events = Some((
+                                    content_block_stop_event,
+                                    delta_event,
+                                    stop_message_event,
+                                ));
+
+                                // Send the remaining text before the stop sequence if any
+                                if !output.is_empty() {
+                                    // Create a content block delta event with the remaining text
+                                    let content_delta = StreamEvent::ContentBlockDelta {
+                                        index,
+                                        delta:
+                                            crate::types::message::ContentBlockDelta::TextDelta {
+                                                text: output,
+                                            },
+                                    };
+
+                                    let output_event = axum::response::sse::Event::default()
+                                        .event("content_block_delta")
+                                        .json_data(&content_delta)
+                                        .unwrap();
+
+                                    // Return the output event with remaining text
+                                    return Poll::Ready(Some(Ok(output_event)));
+                                } else {
+                                    // No remaining text, start sending stop events immediately
+                                    let event_to_send = if let Some((content_block_stop, _, _)) =
+                                        &self.stop_events
+                                    {
+                                        let event = content_block_stop.clone();
+                                        self.stop_event_state = 1;
+                                        Some(event)
+                                    } else {
+                                        None
+                                    };
+
+                                    if let Some(event) = event_to_send {
+                                        return Poll::Ready(Some(Ok(event)));
+                                    } else {
+                                        return Poll::Ready(None);
+                                    }
+                                }
+                            }
+
+                            // No stop sequence matched, convert the event
+                            let event = axum::response::sse::Event::default()
+                                .event(event.event)
+                                .json_data(&StreamEvent::ContentBlockDelta {
+                                    index,
+                                    delta: crate::types::message::ContentBlockDelta::TextDelta {
+                                        text: output,
+                                    },
+                                })
+                                .unwrap();
+
+                            Poll::Ready(Some(Ok(event)))
+                        }
+                        // Pass through other event types
+                        _ => Poll::Ready(Some(Ok(convert_event(event)))),
+                    }
+                } else {
+                    // Not a StreamEvent, pass through
+                    Poll::Ready(Some(Ok(convert_event(event))))
+                }
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+// Helper function to convert from eventsource_stream::Event to axum::response::sse::Event
+fn convert_event(event: EventSourceEvent) -> axum::response::sse::Event {
+    let mut sse_event = axum::response::sse::Event::default();
+
+    if !event.event.is_empty() {
+        sse_event = sse_event.event(event.event);
+    }
+
+    sse_event.data(event.data)
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,8 @@ use tracing::error;
 
 use crate::{IS_DEV, config::LOG_DIR, error::ClewdrError};
 
+pub mod stop_sequence;
+
 /// Helper function to format a boolean value as "Enabled" or "Disabled"
 pub fn enabled(flag: bool) -> ColoredString {
     if flag {

--- a/src/utils/stop_sequence.rs
+++ b/src/utils/stop_sequence.rs
@@ -1,0 +1,364 @@
+use std::collections::HashMap;
+use std::cmp::max;
+use std::sync::{Arc, Mutex};
+
+/// A matcher for stop sequences in text streams.
+/// Characters that might be part of a stop sequence are buffered until they can be confirmed
+/// not to be part of any match, at which point they are immediately returned.
+pub struct StopSequenceMatcher {
+    root: Arc<TrieNode>,                                // Root of the trie data structure (shared)
+    state: Arc<Mutex<StopSequenceState>>,               // Thread-safe mutable state
+}
+
+/// Internal mutable state of the matcher
+struct StopSequenceState {
+    buffered_chars: String,           // Characters being processed
+    active_matches: Vec<ActiveMatch>, // Active match attempts
+}
+
+/// Represents a node in the Trie data structure for efficient string matching.
+#[derive(Clone)]
+struct TrieNode {
+    children: HashMap<char, Arc<TrieNode>>,  // Child nodes mapped by character
+    is_end: bool,                            // Indicates if this node is the end of a sequence
+    sequence: Option<String>,                // The full sequence if this is an end node
+}
+
+/// Represents an active match attempt in progress.
+#[derive(Clone)]
+struct ActiveMatch {
+    node: Arc<TrieNode>,  // Current node in the trie (using Arc instead of raw pointer)
+    buffer: String,       // Characters matched so far
+}
+
+// StopSequenceMatcher is safely Send and Sync because all internal mutable state is protected by Mutex
+// and shared data is wrapped in Arc
+unsafe impl Send for StopSequenceMatcher {}
+unsafe impl Sync for StopSequenceMatcher {}
+
+impl Clone for StopSequenceMatcher {
+    fn clone(&self) -> Self {
+        StopSequenceMatcher {
+            root: self.root.clone(),
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl StopSequenceMatcher {
+    /// Creates a new StopSequenceMatcher with the given stop sequences.
+    ///
+    /// # Arguments
+    /// * `stop_sequences` - List of sequences that should stop processing when matched
+    pub fn new(stop_sequences: &[String]) -> Self {
+        // Create a root node for the trie
+        let mut root = TrieNode::new();
+
+        // Build the trie from the stop sequences
+        for sequence in stop_sequences {
+            let mut node = &mut root;
+            for c in sequence.chars() {
+                node = Arc::get_mut(node.children
+                    .entry(c)
+                    .or_insert_with(|| Arc::new(TrieNode::new())))
+                    .expect("Failed to get mutable reference to TrieNode");
+            }
+            node.is_end = true;
+            node.sequence = Some(sequence.clone());
+        }
+
+        // Create the matcher with thread-safe state
+        StopSequenceMatcher {
+            root: Arc::new(root),
+            state: Arc::new(Mutex::new(StopSequenceState {
+                buffered_chars: String::new(),
+                active_matches: Vec::new(),
+            })),
+        }
+    }
+
+    /// Process a chunk of text and check if any stop sequence is matched
+    ///
+    /// # Arguments
+    /// * `text` - The text to process
+    ///
+    /// # Returns
+    /// A tuple containing:
+    /// - The text that should be sent to the client (may be empty if all text is part of a stop sequence)
+    /// - The matched stop sequence if any
+    pub fn process(&self, text: &str) -> (String, Option<String>) {
+        let mut output = String::new();
+        let mut matched_sequence = None;
+
+        for c in text.chars() {
+            // Process the character
+            let (processed_chars, match_result) = self.process_char(c);
+
+            // Add any processed characters to the output
+            if let Some(chars) = processed_chars {
+                output.push_str(&chars);
+            }
+
+            // If we found a match, return it
+            if let Some(seq) = match_result {
+                matched_sequence = Some(seq);
+                break;
+            }
+        }
+
+        (output, matched_sequence)
+    }
+
+    /// Processes a single character, updating the matching state.
+    ///
+    /// # Arguments
+    /// * `c` - Character to process
+    ///
+    /// # Returns
+    /// A tuple containing:
+    /// - Characters that can be safely output (if any)
+    /// - Matched stop sequence (if any)
+    fn process_char(&self, c: char) -> (Option<String>, Option<String>) {
+        // Lock the state for the duration of this method
+        let mut state = self.state.lock().expect("Failed to lock state mutex");
+
+        // Start a new match from the root for the current character
+        state.active_matches.push(ActiveMatch {
+            node: self.root.clone(),
+            buffer: String::new(),
+        });
+
+        // Add current character to the buffer for potential matches
+        state.buffered_chars.push(c);
+
+        let mut new_active_matches = Vec::new();
+        let mut max_match_length = 0;
+        let mut matched_sequence = None;
+
+        // Process all active matches with the current character
+        for match_state in &state.active_matches {
+            let node = &match_state.node;
+
+            if let Some(next_node) = node.children.get(&c) {
+                // Continue the match by adding the character and updating the node
+                let mut new_buffer = match_state.buffer.clone();
+                new_buffer.push(c);
+
+                let new_match = ActiveMatch {
+                    node: next_node.clone(),
+                    buffer: new_buffer.clone(),
+                };
+
+                if next_node.is_end {
+                    // We found a complete match
+                    matched_sequence = next_node.sequence.clone();
+                    // No need to continue processing
+                    break;
+                }
+
+                new_active_matches.push(new_match);
+                max_match_length = max(max_match_length, new_buffer.len());
+            }
+        }
+
+        // If we found a match, clear state and return the match
+        if let Some(seq) = &matched_sequence {
+            state.buffered_chars.clear();
+            state.active_matches.clear();
+            return (None, Some(seq.clone()));
+        }
+
+        // Output characters that can no longer be part of any match
+        if state.buffered_chars.len() > max_match_length {
+            let chars_to_output = state.buffered_chars.len() - max_match_length;
+            let output = state.buffered_chars[..chars_to_output].to_string();
+            state.buffered_chars = state.buffered_chars[chars_to_output..].to_string();
+
+            // Update active matches for the next iteration
+            state.active_matches = new_active_matches;
+
+            return (Some(output), None);
+        }
+
+        // Update active matches for the next iteration
+        state.active_matches = new_active_matches;
+
+        (None, None)
+    }
+}
+
+impl TrieNode {
+    /// Creates a new TrieNode.
+    fn new() -> Self {
+        TrieNode {
+            children: HashMap::new(),
+            is_end: false,
+            sequence: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_matcher() {
+        let stop_sequences = vec!["stop".to_string(), "halt".to_string()];
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+        // Verify the matcher was created with empty buffer and no active matches
+        let state = matcher.state.lock().unwrap();
+        assert_eq!(state.buffered_chars, "");
+        assert!(state.active_matches.is_empty());
+        drop(state); // Explicitly release the lock
+
+        // Verify the trie structure was built correctly
+        // Check for 's' in the root's children
+        assert!(matcher.root.children.contains_key(&'s'));
+        // Check for 'h' in the root's children
+        assert!(matcher.root.children.contains_key(&'h'));
+    }
+
+    #[test]
+    fn test_simple_match() {
+        let stop_sequences = vec!["stop".to_string()];
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+        // Process a text that contains the stop sequence
+        let (output, matched) = matcher.process("This should stop here");
+
+        // Verify the output contains text before the match
+        assert_eq!(output, "This should ");
+        // Verify the matched sequence
+        assert_eq!(matched, Some("stop".to_string()));
+    }
+
+    #[test]
+    fn test_no_match() {
+        let stop_sequences = vec!["stop".to_string()];
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+        // Process a text that doesn't contain the stop sequence
+        let (output, matched) = matcher.process("This text will be output directly");
+
+        // Verify all text is output
+        assert_eq!(output, "This text will be output directly");
+        // Verify no match was found
+        assert_eq!(matched, None);
+    }
+
+    #[test]
+    fn test_partial_match() {
+        let stop_sequences = vec!["stop".to_string()];
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+        // Process a text that contains part of the stop sequence
+        let (output, matched) = matcher.process("This is st");
+
+        // Verify text before potential match is output
+        assert_eq!(output, "This is ");
+        // Verify no match was found yet
+        assert_eq!(matched, None);
+
+        // Process the rest of the stop sequence
+        let (output2, matched2) = matcher.process("op now");
+
+        // Verify the matched sequence
+        assert_eq!(matched2, Some("stop".to_string()));
+        // No output before the match in the second chunk
+        assert_eq!(output2, "");
+    }
+
+    #[test]
+    fn test_multiple_stop_sequences() {
+        let stop_sequences = vec!["stop".to_string(), "halt".to_string(), "end".to_string()];
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+        // Test with the second stop sequence
+        let (output, matched) = matcher.process("Please halt processing");
+
+        // Verify the output contains text before the match
+        assert_eq!(output, "Please ");
+        // Verify the matched sequence
+        assert_eq!(matched, Some("halt".to_string()));
+
+        // Reset and test with the third stop sequence
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+        let (output, matched) = matcher.process("This is the end of the text");
+
+        // Verify the output contains text before the match
+        assert_eq!(output, "This is the ");
+        // Verify the matched sequence
+        assert_eq!(matched, Some("end".to_string()));
+    }
+
+    #[test]
+    fn test_overlapping_sequences() {
+        let stop_sequences = vec!["stop".to_string(), "stopping".to_string()];
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+        // Process text with the longer sequence
+        let (output, matched) = matcher.process("We are stopping now");
+
+        // Verify the output contains text before the match
+        assert_eq!(output, "We are ");
+        // Verify the matched sequence is the shorter one that appears first
+        assert_eq!(matched, Some("stop".to_string()));
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let stop_sequences = vec!["stop".to_string()];
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+        // Process empty text
+        let (output, matched) = matcher.process("");
+
+        // Verify empty output
+        assert_eq!(output, "");
+        // Verify no match
+        assert_eq!(matched, None);
+    }
+
+    #[test]
+    fn test_empty_stop_sequences() {
+        let stop_sequences: Vec<String> = vec![];
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+        // Process some text
+        let (output, matched) = matcher.process("This text should pass through");
+
+        // Verify all text is output
+        assert_eq!(output, "This text should pass through");
+        // Verify no match
+        assert_eq!(matched, None);
+    }
+
+    #[test]
+    fn test_incremental_processing() {
+        let stop_sequences = vec!["stop".to_string()];
+        let matcher = StopSequenceMatcher::new(&stop_sequences);
+
+        // Process text character by character
+        let (output1, matched1) = matcher.process("T");
+        assert_eq!(output1, "T");
+        assert_eq!(matched1, None);
+
+        let (output2, matched2) = matcher.process("h");
+        assert_eq!(output2, "h");
+        assert_eq!(matched2, None);
+
+        let (output3, matched3) = matcher.process("is is s");
+        assert_eq!(output3, "is is ");
+        assert_eq!(matched3, None);
+
+        let (output4, matched4) = matcher.process("t");
+        assert_eq!(output4, "");
+        assert_eq!(matched4, None);
+
+        let (output5, matched5) = matcher.process("op");
+        assert_eq!(output5, "");
+        assert_eq!(matched5, Some("stop".to_string()));
+    }
+}


### PR DESCRIPTION
## Overview

This PR adds stop sequence processing functionality to ClewdR. The Claude API allows stopping text generation via the `stop_sequences` parameter, but Claude.ai does not support passing this parameter directly. Since some presets may rely on this feature to work properly, we have added stream matching for stop_sequences and the ability to terminate generation in the reverse proxy.

此 PR 为 ClewdR 添加了处理停止序列（stop sequences）的功能。Claude API 允许通过 `stop_sequences` 参数来停止文本生成，但 Claude.ai 不支持直接传入此参数。由于部分预设可能依赖此特性工作，我们在反向代理中添加了流式匹配 stop_sequences 并终止生成的功能。

## Features

1. Added a `StopSequenceMatcher` class for matching stop sequences in text streams
   添加了 `StopSequenceMatcher` 类，用于在文本流中匹配停止序列

   - Supports incremental text processing, immediately returning characters that cannot be matched
     支持增量处理文本，立即返回不可能被匹配的字符

   - Implements efficient string matching using a Trie data structure
     使用 Trie 数据结构实现高效字符串匹配

   - Supports matching multiple stop sequences simultaneously
     支持多个停止序列同时匹配

   - Includes comprehensive unit tests
     包含完整的单元测试

2. Added stop sequence middleware for handling stop sequences in streaming responses
   添加了停止序列中间件，用于处理流式响应中的停止序列

   - Intercepts streaming responses and checks for stop sequences
     拦截流式响应并检查停止序列

   - When a stop sequence is detected: (when a stop sequence is detected)
     当检测到停止序列时：

     1. Sends the remaining text before the stop sequence
        发送停止序列前的剩余文本

     2. Sends a `content_block_stop` event
        发送 `content_block_stop` 事件

     3. Sends a `message_delta` event with `stop_reason: "stop_sequence"` and `stop_sequence` fields
        发送带有 `stop_reason: "stop_sequence"` 和 `stop_sequence` 字段的 `message_delta` 事件

     4. Sends a `message_stop` event
        发送 `message_stop` 事件

     5. Terminates the stream
        终止流
