### PR TITLE
fix  claude code 403 error and action fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ env:
   CARGO_TERM_COLOR: always
   CLEWDR_FEATURE_ARGS: "--no-default-features --features embed-resource,portable"
   APT_PACKAGES: "build-essential cmake perl pkg-config libclang-dev"
-  CHOCOLATEY_PACKAGES: "cmake strawberryperl pkgconfiglite llvm nasm zip"
-  HOMEBREW_PACKAGES: "llvm"
   BIN_NAME: "clewdr"
 permissions:
   contents: write
@@ -28,16 +26,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
           check-latest: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: latest
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Build frontend
         run: |
@@ -107,21 +107,76 @@ jobs:
           ndk-version: r27c
           add-to-path: true
 
-      - name: Install APT Packages
+
+      # macOS: use toolcache action for LLVM
+      - name: Setup LLVM (macOS)
+        if: matrix.os == 'macos'
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: 17
+          directory: ${{ runner.temp }}/llvm
+      - name: Export LIBCLANG_PATH (macOS)
+        if: matrix.os == 'macos'
+        run: echo "LIBCLANG_PATH=${{ runner.temp }}/llvm/lib" >> $GITHUB_ENV
+
+      # Linux: use toolcache action for LLVM
+      - name: Setup LLVM (Linux)
         if: contains(matrix.runner, 'ubuntu')
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: 17
+          directory: ${{ runner.temp }}/llvm
+      - name: Export LIBCLANG_PATH (Linux)
+        if: contains(matrix.runner, 'ubuntu')
+        run: echo "LIBCLANG_PATH=${{ runner.temp }}/llvm/lib" >> $GITHUB_ENV
+
+      # musllinux still requires musl toolchain via apt
+      - name: Install musl APT packages (musllinux only)
+        if: contains(matrix.runner, 'ubuntu') && matrix.os == 'musllinux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ${{ env.APT_PACKAGES }} ${{ matrix.musl_packages }}
+          sudo apt-get install -y ${{ matrix.musl_packages }}
 
-      - name: Install Chocolatey Packages
+      # Windows: use toolcache actions and keep choco only for zip
+      - name: Setup LLVM (Windows)
         if: matrix.os == 'windows'
-        run: choco install ${{ env.CHOCOLATEY_PACKAGES }} -y
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: 17
+          directory: ${{ runner.temp }}/llvm
+      - name: Export LIBCLANG_PATH (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: echo "LIBCLANG_PATH=${{ runner.temp }}\llvm\bin" >> $env:GITHUB_ENV
 
-      - name: Install Homebrew Packages
-        if: matrix.os == 'macos'
+      - name: Setup NASM (Windows)
+        if: matrix.os == 'windows'
+        uses: ilammy/setup-nasm@v1
+
+      - name: Export NASM for CMake (Windows)
+        if: matrix.os == 'windows'
+        shell: bash
         run: |
-          brew update
-          brew install ${{ env.HOMEBREW_PACKAGES }}
+          NASM_PATH=$(command -v nasm || which nasm)
+          echo "CMAKE_ASM_NASM_COMPILER=$NASM_PATH" >> $GITHUB_ENV
+          echo "ASM_NASM=$NASM_PATH" >> $GITHUB_ENV
+
+      - name: Setup CMake (Windows)
+        if: matrix.os == 'windows'
+        uses: jwlawson/actions-setup-cmake@v1
+        with:
+          cmake-version: '3.29.x'
+
+      - name: Setup Perl (Windows)
+        if: matrix.os == 'windows'
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5'
+          distribution: 'strawberry'
+          enable-modules-cache: false
+
+      # No need to install zip on Windows; use 7-Zip built-in
+
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -166,7 +221,11 @@ jobs:
             mv ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/${{ matrix.target_arch }}-linux-android/libc++_shared.so release-package/
           fi
           cd release-package
-          zip -r ../${{ env.BIN_NAME }}-${{ matrix.os }}-${{matrix.target_arch}} .
+          if [ ${{ matrix.os }} == "windows" ]; then
+            7z a -tzip ../${{ env.BIN_NAME }}-${{ matrix.os }}-${{matrix.target_arch}}.zip *
+          else
+            zip -r ../${{ env.BIN_NAME }}-${{ matrix.os }}-${{matrix.target_arch}}.zip .
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,8 @@ jobs:
           brew install ${{ env.HOMEBREW_PACKAGES }}
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ steps.target.outputs.triple }}
 
       - name: Download static files
         uses: actions/download-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ static/
 /clewdr*.toml
 /cline_docs
 .idea
+.codex

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ static/
 /cline_docs
 .idea
 .codex
+test
+scripts

--- a/src/config/reason.rs
+++ b/src/config/reason.rs
@@ -18,6 +18,8 @@ pub enum Reason {
     Disabled,
     Banned,
     Null,
+    /// Upstream returned 403 Forbidden; message provides additional context
+    Forbidden(String),
     Restricted(i64),
     TooManyRequest(i64),
 }
@@ -36,6 +38,7 @@ impl Display for Reason {
             Reason::NonPro => write!(f, "Free account"),
             Reason::Banned => write!(f, "Banned"),
             Reason::Null => write!(f, "Null"),
+            Reason::Forbidden(msg) => write!(f, "403 Forbidden: {}", msg),
             Reason::Restricted(i) => {
                 write!(f, "Restricted/Warning: until {}", colored_time(*i))
             }

--- a/src/config/reason.rs
+++ b/src/config/reason.rs
@@ -18,8 +18,6 @@ pub enum Reason {
     Disabled,
     Banned,
     Null,
-    /// Upstream returned 403 Forbidden; message provides additional context
-    Forbidden(String),
     Restricted(i64),
     TooManyRequest(i64),
 }
@@ -38,7 +36,6 @@ impl Display for Reason {
             Reason::NonPro => write!(f, "Free account"),
             Reason::Banned => write!(f, "Banned"),
             Reason::Null => write!(f, "Null"),
-            Reason::Forbidden(msg) => write!(f, "403 Forbidden: {}", msg),
             Reason::Restricted(i) => {
                 write!(f, "Restricted/Warning: until {}", colored_time(*i))
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -407,7 +407,6 @@ impl CheckClaudeErr for Response {
             return Err(Reason::Null.into());
         }
         if status == 403 {
-            // Only invalidate cookie when message contains the specific phrase (case-insensitive)
             let msg = match &err.error.message {
                 serde_json::Value::String(s) => s.clone(),
                 v => v.to_string(),
@@ -415,9 +414,7 @@ impl CheckClaudeErr for Response {
             let msg_lower = msg.to_ascii_lowercase();
             let phrase = "oauth authentication is currently not allowed for this organization";
             if msg_lower.contains(phrase) {
-                return Err(ClewdrError::InvalidCookie {
-                    reason: Reason::Forbidden(msg),
-                });
+                return Err(Reason::Null.into());
             } else {
                 return Err(ClewdrError::ClaudeHttpError {
                     code: status,


### PR DESCRIPTION
This pull request refactors the CI build workflow in `.github/workflows/build.yml` to improve platform-specific package installation and tool setup, making the process more robust and maintainable. It also adds more precise error handling for HTTP 403 responses in `src/error.rs`. The most important changes are grouped below.

**CI Workflow Improvements:**

* Replaces platform-specific package installation via Chocolatey and Homebrew with dedicated setup actions for LLVM, NASM, CMake, and Perl on Windows and macOS, and uses KyleMayes/install-llvm-action for LLVM setup across all platforms. This streamlines and standardizes tool installation. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L18-L19) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L110-R183)
* Refactors the frontend build step to install pnpm before Node.js setup and enables pnpm caching using `frontend/pnpm-lock.yaml`, improving build efficiency.
* Adjusts artifact packaging: uses 7-Zip for Windows builds and zip for others, ensuring compatibility and reliability in release packaging.

**Error Handling Enhancement:**

* Adds special case handling for HTTP 403 errors from Claude API: if the error message contains the phrase "oauth authentication is currently not allowed for this organization", it returns a null reason; otherwise, it returns a detailed ClaudeHttpError. This provides clearer and more accurate error reporting.