### PR TITLE
feat(client): update proxy and endpoint retrieval in cookie request h…

### DIFF
--- a/src/claude_code_state/mod.rs
+++ b/src/claude_code_state/mod.rs
@@ -89,6 +89,9 @@ impl ClaudeCodeState {
             .await?;
         self.cookie = Some(res.to_owned());
         self.cookie_header_value = HeaderValue::from_str(res.cookie.to_string().as_str())?;
+        // Always pull latest proxy/endpoint before building the client
+        self.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
+        self.endpoint = CLEWDR_CONFIG.load().endpoint();
         let mut client = ClientBuilder::new()
             .cookie_store(true)
             .emulation(Emulation::Chrome136);
@@ -98,8 +101,6 @@ impl ClaudeCodeState {
         self.client = client.build().context(WreqSnafu {
             msg: "Failed to build client with new cookie",
         })?;
-        // load newest config
-        self.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
         Ok(res)
     }
 

--- a/src/claude_web_state/mod.rs
+++ b/src/claude_web_state/mod.rs
@@ -104,6 +104,9 @@ impl ClaudeWebState {
     pub async fn request_cookie(&mut self) -> Result<CookieStatus, ClewdrError> {
         let res = self.cookie_actor_handle.request(None).await?;
         self.cookie = Some(res.to_owned());
+        // Always pull latest proxy/endpoint before building the client
+        self.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
+        self.endpoint = CLEWDR_CONFIG.load().endpoint();
         let mut client = ClientBuilder::new()
             .cookie_store(true)
             .emulation(Emulation::Chrome136);
@@ -114,9 +117,6 @@ impl ClaudeWebState {
             msg: "Failed to build client with new cookie",
         })?;
         self.cookie_header_value = HeaderValue::from_str(res.cookie.to_string().as_str())?;
-        // load newest config
-        self.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
-        self.endpoint = CLEWDR_CONFIG.load().endpoint();
         Ok(res)
     }
 


### PR DESCRIPTION
This pull request updates the logic for refreshing proxy and endpoint configuration in both `ClaudeCodeState` and `ClaudeWebState`. The main improvement is to ensure that the latest proxy and endpoint settings are always loaded before building the HTTP client, rather than after. This makes sure the client uses up-to-date configuration immediately after a cookie is requested.

Configuration refresh improvements:

* In `ClaudeCodeState` (`src/claude_code_state/mod.rs`), moved the loading of the proxy and endpoint from after the client build to before, ensuring the client uses the latest configuration. [[1]](diffhunk://#diff-2e644b4a982d4f88c884a1cb41bc41623b7f0e1662d2dff7a128f33fe2618763R92-R94) [[2]](diffhunk://#diff-2e644b4a982d4f88c884a1cb41bc41623b7f0e1662d2dff7a128f33fe2618763L101-L102)
* In `ClaudeWebState` (`src/claude_web_state/mod.rs`), similarly moved the loading of the proxy and endpoint to before the client build, and removed the redundant loading after client creation. [[1]](diffhunk://#diff-b09273481bb042065a0da2b1019b2d6f720cecfb38ca8e2b19903a42f72afa4eR107-R109) [[2]](diffhunk://#diff-b09273481bb042065a0da2b1019b2d6f720cecfb38ca8e2b19903a42f72afa4eL117-L119)…andling