### PR TITLE
Proxy hot reload

### DIFF
--- a/src/claude_code_state/mod.rs
+++ b/src/claude_code_state/mod.rs
@@ -89,6 +89,9 @@ impl ClaudeCodeState {
             .await?;
         self.cookie = Some(res.to_owned());
         self.cookie_header_value = HeaderValue::from_str(res.cookie.to_string().as_str())?;
+        // Always pull latest proxy/endpoint before building the client
+        self.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
+        self.endpoint = CLEWDR_CONFIG.load().endpoint();
         let mut client = ClientBuilder::new()
             .cookie_store(true)
             .emulation(Emulation::Chrome136);
@@ -98,8 +101,6 @@ impl ClaudeCodeState {
         self.client = client.build().context(WreqSnafu {
             msg: "Failed to build client with new cookie",
         })?;
-        // load newest config
-        self.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
         Ok(res)
     }
 

--- a/src/claude_web_state/mod.rs
+++ b/src/claude_web_state/mod.rs
@@ -104,6 +104,9 @@ impl ClaudeWebState {
     pub async fn request_cookie(&mut self) -> Result<CookieStatus, ClewdrError> {
         let res = self.cookie_actor_handle.request(None).await?;
         self.cookie = Some(res.to_owned());
+        // Always pull latest proxy/endpoint before building the client
+        self.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
+        self.endpoint = CLEWDR_CONFIG.load().endpoint();
         let mut client = ClientBuilder::new()
             .cookie_store(true)
             .emulation(Emulation::Chrome136);
@@ -114,9 +117,6 @@ impl ClaudeWebState {
             msg: "Failed to build client with new cookie",
         })?;
         self.cookie_header_value = HeaderValue::from_str(res.cookie.to_string().as_str())?;
-        // load newest config
-        self.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
-        self.endpoint = CLEWDR_CONFIG.load().endpoint();
         Ok(res)
     }
 

--- a/src/gemini_state/mod.rs
+++ b/src/gemini_state/mod.rs
@@ -104,12 +104,10 @@ impl GeminiState {
     pub async fn request_key(&mut self) -> Result<(), ClewdrError> {
         let key = self.key_handle.request().await?;
         self.key = Some(key.to_owned());
-        let client = ClientBuilder::new();
-        let client = if let Some(proxy) = CLEWDR_CONFIG.load().proxy.to_owned() {
-            client.proxy(proxy)
-        } else {
-            client
-        };
+        let mut client = ClientBuilder::new();
+        if let Some(proxy) = CLEWDR_CONFIG.load().wreq_proxy.to_owned() {
+            client = client.proxy(proxy);
+        }
         self.client = client.build().context(WreqSnafu {
             msg: "Failed to build Gemini client",
         })?;
@@ -129,12 +127,10 @@ impl GeminiState {
         &mut self,
         p: impl Sized + Serialize,
     ) -> Result<wreq::Response, ClewdrError> {
-        let client = ClientBuilder::new();
-        let client = if let Some(proxy) = CLEWDR_CONFIG.load().proxy.to_owned() {
-            client.proxy(proxy)
-        } else {
-            client
-        };
+        let mut client = ClientBuilder::new();
+        if let Some(proxy) = CLEWDR_CONFIG.load().wreq_proxy.to_owned() {
+            client = client.proxy(proxy);
+        }
         self.client = client.build().context(WreqSnafu {
             msg: "Failed to build Gemini client",
         })?;


### PR DESCRIPTION
This pull request refactors how proxy and endpoint configuration is loaded and applied when building HTTP clients in the `ClaudeCodeState`, `ClaudeWebState`, and `GeminiState` modules. The main improvement is to ensure that the latest values from `CLEWDR_CONFIG` are always used immediately before client construction, which helps avoid stale configuration and improves reliability.

**Configuration loading improvements:**

* In both `ClaudeCodeState` and `ClaudeWebState`, the latest `wreq_proxy` and `endpoint` values are now explicitly loaded from `CLEWDR_CONFIG` right before building the client, ensuring up-to-date configuration is always used. [[1]](diffhunk://#diff-2e644b4a982d4f88c884a1cb41bc41623b7f0e1662d2dff7a128f33fe2618763R92-R94) [[2]](diffhunk://#diff-b09273481bb042065a0da2b1019b2d6f720cecfb38ca8e2b19903a42f72afa4eR107-R109)
* Removed redundant or duplicate config loading after client creation in both `ClaudeCodeState` and `ClaudeWebState` to streamline the process and avoid unnecessary operations. [[1]](diffhunk://#diff-2e644b4a982d4f88c884a1cb41bc41623b7f0e1662d2dff7a128f33fe2618763L101-L102) [[2]](diffhunk://#diff-b09273481bb042065a0da2b1019b2d6f720cecfb38ca8e2b19903a42f72afa4eL117-L119)

**Proxy handling standardization in GeminiState:**

* Updated proxy assignment logic in `GeminiState` to consistently use `wreq_proxy` from `CLEWDR_CONFIG`, replacing previous usage of `proxy`, and refactored the client construction to use a mutable builder pattern for clarity. [[1]](diffhunk://#diff-3a035cc9cbbf0a1ee9b82f465c26b0ae87abbd778deb177162e84186d0c0e526L107-R110) [[2]](diffhunk://#diff-3a035cc9cbbf0a1ee9b82f465c26b0ae87abbd778deb177162e84186d0c0e526L132-R133)