### PR TITLE
Release v0.11.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,7 +649,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clewdr"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "arc-swap",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clewdr"
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 authors = ["Xerxes-2"]
 license = "AGPL-3.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,30 +1,21 @@
-# v0.11.15
+# v0.11.17
 
 ## Features
 
-- Claude 4.5 support
-  - Update model prefixes and request handling for Claude 3.7 Sonnet (2025-02-19).
-  - Add token usage tracking and `count_tokens` endpoints (Code/Web).
-  - Add config toggle to enable web `count_tokens`.
-  - Cookie management enhancements: 1M-context capability flag and visualization; current/total token usage fields.
-- Cookie quota visualization
-  - `/api/cookies` now returns ephemeral quota utilization: 5-hour session, 7-day, and 7-day Opus (percent).
-  - Also returns corresponding reset timestamps (ISO 8601). Frontend shows expandable details.
-- Gemini support and management
-  - AI Studio and Vertex proxy, providing OpenAI-compatible `chat/completions`.
-  - Admin APIs: submit/delete Gemini keys; list/add/delete Vertex service account credentials.
-  - Frontend Gemini tab: key submission/visualization; Vertex credential list and upload.
-- Persistence and admin
-  - Add storage Import/Export/Status endpoints (available when built with `db` feature).
-  - Settings page shows storage status summary and provides Import/Export (enabled in non-file modes).
+- Cookie usage breakdown by model family
+  - Add session/7‑day/7‑day Opus/lifetime usage buckets with per‑family totals (Sonnet, Opus) alongside overall totals (input/output tokens).
+  - Frontend visualization now expands each window to show Sonnet/Opus input/output when present.
+  - Storage layer persists the new UsageBreakdown structures when DB persistence is enabled.
 
 ## Improvements
 
-- Ensure log directory exists before writing when file logging is enabled.
-- Install aws-lc crypto provider before using rustls to improve TLS stability.
-- Settings UI: remove legacy Vertex Settings section; update related copy and translations.
-- Refine DB initialization and storage health reporting; tidy provider abstractions and router structure.
+- Settings: decouple Vertex from the Config page
+  - The Config page payload no longer includes `vertex`; Vertex credentials are managed exclusively under the Gemini tab.
+  - Server preserves existing Vertex configuration on config updates regardless of request body contents.
+  - GET /api/config no longer returns Vertex fields to the frontend to avoid accidental round‑trips.
+- API ergonomics
+  - Change Config update to POST semantics and enhance error propagation so the UI surfaces backend error messages.
 
 ## Bug Fixes
 
-- Docs: clarify private key handling for Google Cloud service account JSON.
+- Fix 422 on config save when a placeholder `vertex.credential` string was round‑tripped from the UI. The endpoint now ignores Vertex from the Config page and preserves existing values.

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -149,17 +149,29 @@ import type { ConfigData } from "../types/config.types";
 
 export async function saveConfig(configData: ConfigData) {
   const token = localStorage.getItem("authToken") || "";
+  // The config page no longer manages Vertex credentials.
+  // Exclude `vertex` from the payload to avoid accidental type mismatches
+  // with the backend's ServiceAccountKey structure and to preserve
+  // credentials managed in the Gemini section.
+  const { vertex: _omitVertex, ...payload } = (configData as unknown) as Record<string, unknown>;
   const response = await fetch("/api/config", {
-    method: "PUT",
+    method: "POST",
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify(configData),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to save config: ${response.status}`);
+    // Try to include server error message when available for easier debugging
+    try {
+      const data = await response.json();
+      const serverMsg = typeof data?.error === "string" ? ` - ${data.error}` : "";
+      throw new Error(`Failed to save config: ${response.status}${serverMsg}`);
+    } catch (_) {
+      throw new Error(`Failed to save config: ${response.status}`);
+    }
   }
 
   return response;

--- a/frontend/src/components/claude/CookieVisualization.tsx
+++ b/frontend/src/components/claude/CookieVisualization.tsx
@@ -62,48 +62,52 @@ const CookieVisualization: React.FC = () => {
   };
 
   const renderUsageStats = (status: CookieItem) => {
-    const rec = status as unknown as Record<string, unknown>;
-    const pickNumber = (a: unknown, b: unknown): number =>
-      typeof a === "number" ? a : typeof b === "number" ? (b as number) : 0;
-    const currentInput = pickNumber(
-      status.window_input_tokens,
-      rec["windowInputTokens"],
-    );
-    const currentOutput = pickNumber(
-      status.window_output_tokens,
-      rec["windowOutputTokens"],
-    );
-    const totalInput = pickNumber(
-      status.total_input_tokens,
-      rec["totalInputTokens"],
-    );
-    const totalOutput = pickNumber(
-      status.total_output_tokens,
-      rec["totalOutputTokens"],
-    );
 
-    if (currentInput === 0 && currentOutput === 0 && totalInput === 0 && totalOutput === 0) {
-      return null;
-    }
+    // New buckets (session/7d/7d-opus)
+    const sIn = status.session_usage?.total_input_tokens ?? 0;
+    const sOut = status.session_usage?.total_output_tokens ?? 0;
+    const wIn = status.weekly_usage?.total_input_tokens ?? 0;
+    const wOut = status.weekly_usage?.total_output_tokens ?? 0;
+    const woIn = status.weekly_opus_usage?.total_input_tokens ?? 0;
+    const woOut = status.weekly_opus_usage?.total_output_tokens ?? 0;
+    const ltIn = status.lifetime_usage?.total_input_tokens ?? 0;
+    const ltOut = status.lifetime_usage?.total_output_tokens ?? 0;
+
+    // If everything is zero, display nothing
+    const nothing = [sIn, sOut, wIn, wOut, woIn, woOut, ltIn, ltOut].every(
+      (n) => (n ?? 0) === 0,
+    );
+    if (nothing) return null;
+
+    const Group = ({ title, input, output }: { title: string; input: number; output: number }) => (
+      <div className="flex gap-3 flex-wrap">
+        <span>
+          {title} · {t("cookieStatus.usage.totalInput")}: {input}
+        </span>
+        <span>
+          {t("cookieStatus.usage.totalOutput")}: {output}
+        </span>
+      </div>
+    );
 
     return (
       <div className="grid gap-1 text-xs text-gray-400">
-        <div className="flex gap-3 flex-wrap">
-          <span>
-            {t("cookieStatus.usage.currentInput")}: {currentInput}
-          </span>
-          <span>
-            {t("cookieStatus.usage.currentOutput")}: {currentOutput}
-          </span>
-        </div>
-        <div className="flex gap-3 flex-wrap">
-          <span>
-            {t("cookieStatus.usage.totalInput")}: {totalInput}
-          </span>
-          <span>
-            {t("cookieStatus.usage.totalOutput")}: {totalOutput}
-          </span>
-        </div>
+        {(sIn > 0 || sOut > 0) && (
+          <Group title={t("cookieStatus.quota.session") as string} input={sIn} output={sOut} />
+        )}
+        {(wIn > 0 || wOut > 0) && (
+          <Group title={t("cookieStatus.quota.sevenDay") as string} input={wIn} output={wOut} />
+        )}
+        {(woIn > 0 || woOut > 0) && (
+          <Group
+            title={t("cookieStatus.quota.sevenDayOpus") as string}
+            input={woIn}
+            output={woOut}
+          />
+        )}
+        {(ltIn > 0 || ltOut > 0) && (
+          <Group title={t("cookieStatus.quota.total") as string} input={ltIn} output={ltOut} />
+        )}
       </div>
     );
   };

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -131,7 +131,11 @@
       "currentInput": "Current input tokens",
       "currentOutput": "Current output tokens",
       "totalInput": "Total input tokens",
-      "totalOutput": "Total output tokens"
+      "totalOutput": "Total output tokens",
+      "sonnetInput": "Sonnet input tokens",
+      "sonnetOutput": "Sonnet output tokens",
+      "opusInput": "Opus input tokens",
+      "opusOutput": "Opus output tokens"
     },
     "quota": {
       "session": "Session utilization",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -137,6 +137,7 @@
       "session": "Session utilization",
       "sevenDay": "7-day utilization",
       "sevenDayOpus": "7-day Opus utilization",
+      "total": "Total usage",
       "resetsAt": "Resets at {{time}}"
     },
     "meta": {

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -131,7 +131,11 @@
       "currentInput": "本轮输入 Token",
       "currentOutput": "本轮输出 Token",
       "totalInput": "累计输入 Token",
-      "totalOutput": "累计输出 Token"
+      "totalOutput": "累计输出 Token",
+      "sonnetInput": "Sonnet 输入 Token",
+      "sonnetOutput": "Sonnet 输出 Token",
+      "opusInput": "Opus 输入 Token",
+      "opusOutput": "Opus 输出 Token"
     },
     "quota": {
       "session": "会话配额使用",

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -137,6 +137,7 @@
       "session": "会话配额使用",
       "sevenDay": "7日配额使用",
       "sevenDayOpus": "7日Opus配额使用",
+      "total": "累计用量",
       "resetsAt": "重置于 {{time}}"
     },
     "meta": {

--- a/frontend/src/types/cookie.types.ts
+++ b/frontend/src/types/cookie.types.ts
@@ -1,13 +1,23 @@
 // frontend/src/types/cookie.types.ts
+export interface UsageBreakdown {
+  total_input_tokens?: number;
+  total_output_tokens?: number;
+  sonnet_input_tokens?: number;
+  sonnet_output_tokens?: number;
+  opus_input_tokens?: number;
+  opus_output_tokens?: number;
+}
+
 export interface CookieStatus {
   cookie: string;
   reset_time: number | null;
   supports_claude_1m?: boolean | null;
   count_tokens_allowed?: boolean | null;
-  total_input_tokens?: number;
-  total_output_tokens?: number;
-  window_input_tokens?: number;
-  window_output_tokens?: number;
+  // New usage buckets
+  session_usage?: UsageBreakdown;
+  weekly_usage?: UsageBreakdown;
+  weekly_opus_usage?: UsageBreakdown;
+  lifetime_usage?: UsageBreakdown;
   // Ephemeral quota utilizations (percent), attached by /api/cookies only
   session_utilization?: number;
   seven_day_utilization?: number;

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -28,7 +28,10 @@ pub async fn api_get_config(
         obj.remove("wasted_cookie");
         obj.remove("gemini_keys");
         if let Some(vertex) = obj.get_mut("vertex").and_then(|v| v.as_object_mut()) {
-            vertex.insert("credential".to_string(), json!("placeholder"));
+            // Do not leak sensitive fields to the frontend. Use null instead of a string
+            // placeholder so that round-tripping the config back to the server deserializes
+            // correctly (Option<ServiceAccountKey> accepts null).
+            vertex.insert("credential".to_string(), serde_json::Value::Null);
             vertex.insert("credentials".to_string(), json!([]));
         }
     }
@@ -60,10 +63,8 @@ pub async fn api_post_config(
         new_c.cookie_array = old_c.cookie_array.to_owned();
         new_c.wasted_cookie = old_c.wasted_cookie.to_owned();
         new_c.gemini_keys = old_c.gemini_keys.to_owned();
-        if new_c.vertex.credentials.is_empty() && new_c.vertex.credential.is_none() {
-            new_c.vertex.credentials = old_c.vertex.credentials.to_owned();
-            new_c.vertex.credential = old_c.vertex.credential.to_owned();
-        }
+        // Vertex is not managed by the config page anymore. Always preserve existing vertex config.
+        new_c.vertex = old_c.vertex.clone();
         new_c
     });
     if let Err(e) = CLEWDR_CONFIG.load().save().await {

--- a/src/claude_code_state/chat.rs
+++ b/src/claude_code_state/chat.rs
@@ -17,9 +17,6 @@ use wreq_util::Emulation;
 
 const CLAUDE_BETA_BASE: &str = "oauth-2025-04-20";
 const CLAUDE_BETA_CONTEXT_1M: &str = "oauth-2025-04-20,context-1m-2025-08-07";
-const CLAUDE_SONNET_4_PREFIX: &str = "claude-sonnet-4-20250514";
-const CLAUDE_SONNET_4_5_PREFIX: &str = "claude-sonnet-4-5-20250929";
-const CLAUDE_SONNET_4_PREFIXES: &[&str] = &[CLAUDE_SONNET_4_PREFIX, CLAUDE_SONNET_4_5_PREFIX];
 
 impl ClaudeCodeState {
     /// Attempts to send a chat message to Claude API with retry mechanism
@@ -544,9 +541,10 @@ impl ClaudeCodeState {
     }
 
     fn is_sonnet4_model(model: &str) -> bool {
-        CLAUDE_SONNET_4_PREFIXES
-            .iter()
-            .any(|prefix| model.starts_with(prefix))
+        // Simplify detection: treat any model id containing
+        // "claude-sonnet-4" as Sonnet 4.x for 1M probing.
+        let m = model.to_ascii_lowercase();
+        m.contains("claude-sonnet-4")
     }
 
     fn classify_model(model: &str) -> ModelFamily {

--- a/src/claude_code_state/chat.rs
+++ b/src/claude_code_state/chat.rs
@@ -8,10 +8,12 @@ use tracing::{Instrument, error, info, warn};
 
 use crate::{
     claude_code_state::{ClaudeCodeState, TokenStatus},
-    config::CLEWDR_CONFIG,
+    config::{ModelFamily, CLEWDR_CONFIG, CLAUDE_CONSOLE_ENDPOINT},
     error::{CheckClaudeErr, ClewdrError, WreqSnafu},
     types::claude::{CountMessageTokensResponse, CreateMessageParams},
 };
+use wreq::{ClientBuilder, Method, Url, header::{ORIGIN, REFERER}};
+use wreq_util::Emulation;
 
 const CLAUDE_BETA_BASE: &str = "oauth-2025-04-20";
 const CLAUDE_BETA_CONTEXT_1M: &str = "oauth-2025-04-20,context-1m-2025-08-07";
@@ -133,13 +135,14 @@ impl ClaudeCodeState {
         };
 
         p.model = base_model;
+        let model_family = Self::classify_model(&p.model);
 
         let mut last_err: Option<ClewdrError> = None;
         for (idx, use_1m) in attempts.iter().copied().enumerate() {
             match self.execute_claude_request(&access_token, &p, use_1m).await {
                 Ok(response) => {
                     return self
-                        .handle_success_response(response, is_sonnet && use_1m)
+                        .handle_success_response(response, is_sonnet && use_1m, model_family)
                         .await;
                 }
                 Err(err) => {
@@ -372,14 +375,12 @@ impl ClaudeCodeState {
         &mut self,
         response: wreq::Response,
         mark_support_true: bool,
+        model_family: ModelFamily,
     ) -> Result<axum::response::Response, ClewdrError> {
         if !self.stream {
             let (resp, usage_pair) = Self::materialize_non_stream_response(response).await?;
-            let (mut input, output) = usage_pair.unwrap_or((self.usage.input_tokens as u64, 0));
-            if input == 0 {
-                input = self.usage.input_tokens as u64;
-            }
-            self.persist_usage_totals(input, output).await;
+            let (input, output) = usage_pair.unwrap_or((self.usage.input_tokens as u64, 0));
+            self.persist_usage_totals(input, output, model_family).await;
             if mark_support_true {
                 self.persist_claude_1m_support(true).await;
             }
@@ -389,16 +390,18 @@ impl ClaudeCodeState {
                 self.persist_claude_1m_support(true).await;
             }
             // Stream pass-through while accumulating output token usage from message_delta events
-            return self.forward_stream_with_usage(response).await;
+            return self.forward_stream_with_usage(response, model_family).await;
         }
     }
 
-    async fn persist_usage_totals(&mut self, input: u64, output: u64) {
+    async fn persist_usage_totals(&mut self, input: u64, output: u64, family: ModelFamily) {
         if input == 0 && output == 0 {
             return;
         }
         if let Some(cookie) = self.cookie.as_mut() {
-            cookie.add_usage(input, output);
+            // Lazy boundary refresh if due, then reset period counters and start fresh
+            Self::update_cookie_boundaries_if_due(cookie).await;
+            cookie.add_and_bucket_usage(input, output, family);
             let cloned = cookie.clone();
             if let Err(err) = self.cookie_actor_handle.return_cookie(cloned, None).await {
                 warn!("Failed to persist usage statistics: {}", err);
@@ -409,6 +412,7 @@ impl ClaudeCodeState {
     async fn forward_stream_with_usage(
         &mut self,
         response: wreq::Response,
+        family: ModelFamily,
     ) -> Result<axum::response::Response, ClewdrError> {
         use std::sync::{
             Arc,
@@ -436,7 +440,9 @@ impl ClaudeCodeState {
                             let total_out = osum.load(Ordering::Relaxed);
                             let mut c = cookie.clone();
                             tokio::spawn(async move {
-                                c.add_usage(input_tokens, total_out);
+                                // Update period boundaries if needed, then accumulate
+                                ClaudeCodeState::update_cookie_boundaries_if_due(&mut c).await;
+                                c.add_and_bucket_usage(input_tokens, total_out, family);
                                 let _ = handle.return_cookie(c, None).await;
                             });
                         }
@@ -541,6 +547,193 @@ impl ClaudeCodeState {
         CLAUDE_SONNET_4_PREFIXES
             .iter()
             .any(|prefix| model.starts_with(prefix))
+    }
+
+    fn classify_model(model: &str) -> ModelFamily {
+        let m = model.to_ascii_lowercase();
+        if m.contains("opus") {
+            ModelFamily::Opus
+        } else if m.contains("sonnet") {
+            ModelFamily::Sonnet
+        } else {
+            ModelFamily::Other
+        }
+    }
+
+    // ---------------------------------------------
+    // Lazy boundary refresh (no timers, fetch-on-due)
+    // ---------------------------------------------
+    async fn update_cookie_boundaries_if_due(cookie: &mut crate::config::CookieStatus) {
+        let now = chrono::Utc::now().timestamp();
+        const SESSION_WINDOW_SECS: i64 = 5 * 60 * 60; // 5h
+        const WEEKLY_WINDOW_SECS: i64 = 7 * 24 * 60 * 60; // 7d
+
+        let tracked = |flag: Option<bool>| flag == Some(true);
+        let unknown = |flag: Option<bool>| flag.is_none();
+        let due = |ts: Option<i64>| ts.map(|t| now >= t).unwrap_or(false);
+
+        let session_tracked = tracked(cookie.session_has_reset);
+        let weekly_tracked = tracked(cookie.weekly_has_reset);
+        let opus_tracked = tracked(cookie.weekly_opus_has_reset);
+
+        let session_due = session_tracked && due(cookie.session_resets_at);
+        let weekly_due = weekly_tracked && due(cookie.weekly_resets_at);
+        let opus_due = opus_tracked && due(cookie.weekly_opus_resets_at);
+
+        let need_probe_unknown = unknown(cookie.session_has_reset)
+            || unknown(cookie.weekly_has_reset)
+            || unknown(cookie.weekly_opus_has_reset);
+        let any_due = session_due || weekly_due || opus_due;
+
+        if !(need_probe_unknown || any_due) {
+            return;
+        }
+
+        cookie.resets_last_checked_at = Some(now);
+        if let Some((sess, week, opus)) = Self::fetch_usage_resets(&cookie.cookie).await {
+            // Unknown -> decide track/not-track
+            if unknown(cookie.session_has_reset) {
+                cookie.session_has_reset = Some(sess.is_some());
+            }
+            if unknown(cookie.weekly_has_reset) {
+                cookie.weekly_has_reset = Some(week.is_some());
+            }
+            if unknown(cookie.weekly_opus_has_reset) {
+                cookie.weekly_opus_has_reset = Some(opus.is_some());
+            }
+
+            // Handle due tracked windows: reset usage then update boundaries if provided
+            if session_due {
+                cookie.session_usage = crate::config::UsageBreakdown::default();
+            }
+            if weekly_due {
+                cookie.weekly_usage = crate::config::UsageBreakdown::default();
+            }
+            if opus_due {
+                cookie.weekly_opus_usage = crate::config::UsageBreakdown::default();
+            }
+
+            // Update/reset boundaries for tracked windows
+            if cookie.session_has_reset == Some(true) {
+                if let Some(ts) = sess {
+                    cookie.session_resets_at = Some(ts);
+                } else {
+                    // Server indicates no boundary -> stop tracking and clear ts
+                    cookie.session_has_reset = Some(false);
+                    cookie.session_resets_at = None;
+                }
+            }
+            if cookie.weekly_has_reset == Some(true) {
+                if let Some(ts) = week {
+                    cookie.weekly_resets_at = Some(ts);
+                } else {
+                    cookie.weekly_has_reset = Some(false);
+                    cookie.weekly_resets_at = None;
+                }
+            }
+            if cookie.weekly_opus_has_reset == Some(true) {
+                if let Some(ts) = opus {
+                    cookie.weekly_opus_resets_at = Some(ts);
+                } else {
+                    cookie.weekly_opus_has_reset = Some(false);
+                    cookie.weekly_opus_resets_at = None;
+                }
+            }
+        } else {
+            // Network/parse failure: apply fallback only for windows we currently track
+            if session_due && session_tracked {
+                cookie.session_usage = crate::config::UsageBreakdown::default();
+                cookie.session_resets_at = Some(now + SESSION_WINDOW_SECS);
+            }
+            if weekly_due && weekly_tracked {
+                cookie.weekly_usage = crate::config::UsageBreakdown::default();
+                cookie.weekly_resets_at = Some(now + WEEKLY_WINDOW_SECS);
+            }
+            if opus_due && opus_tracked {
+                cookie.weekly_opus_usage = crate::config::UsageBreakdown::default();
+                cookie.weekly_opus_resets_at = Some(now + WEEKLY_WINDOW_SECS);
+            }
+        }
+    }
+
+    async fn fetch_usage_resets(
+        cookie: &crate::config::ClewdrCookie,
+    ) -> Option<(Option<i64>, Option<i64>, Option<i64>)> {
+        // Build a fresh client (mirrors misc.rs behavior)
+        let mut builder = ClientBuilder::new()
+            .cookie_store(true)
+            .emulation(Emulation::Chrome136);
+        if let Some(proxy) = CLEWDR_CONFIG.load().wreq_proxy.clone() {
+            builder = builder.proxy(proxy);
+        }
+        let client = builder.build().ok()?;
+
+        // Attach cookie for both api and console domains
+        let endpoint: Url = CLEWDR_CONFIG.load().endpoint();
+        let cookie_header = http::HeaderValue::from_str(&cookie.to_string()).ok()?;
+        client.set_cookie(&endpoint, &cookie_header);
+        let console_url = Url::parse(CLAUDE_CONSOLE_ENDPOINT).ok()?;
+        client.set_cookie(&console_url, &cookie_header);
+
+        // Discover organization UUID (prefer chat-capable org)
+        let orgs_url = format!(
+            "{}/api/organizations",
+            endpoint.as_str().trim_end_matches('/')
+        );
+        let orgs_res = client
+            .request(Method::GET, orgs_url)
+            .header(ORIGIN, crate::config::CLAUDE_ENDPOINT)
+            .header(REFERER, format!("{}/new", crate::config::CLAUDE_ENDPOINT))
+            .send()
+            .await
+            .ok()?;
+        let orgs_val: serde_json::Value = orgs_res.json().await.ok()?;
+        let org_uuid = orgs_val
+            .as_array()
+            .and_then(|a| {
+                a.iter()
+                    .filter(|v| {
+                        v.get("capabilities")
+                            .and_then(|c| c.as_array())
+                            .map(|c| c.iter().any(|x| x.as_str() == Some("chat")))
+                            .unwrap_or(false)
+                    })
+                    .max_by_key(|v| {
+                        v.get("capabilities")
+                            .and_then(|c| c.as_array())
+                            .map(|c| c.len())
+                            .unwrap_or_default()
+                    })
+                    .and_then(|v| v.get("uuid").and_then(|u| u.as_str()))
+            })
+            .or_else(|| {
+                orgs_val
+                    .get(0)
+                    .and_then(|v| v.get("uuid").and_then(|u| u.as_str()))
+            })?;
+
+        // Query usage from console API
+        let usage_url = format!(
+            "{}/api/organizations/{}/usage",
+            CLAUDE_CONSOLE_ENDPOINT, org_uuid
+        );
+        let usage_res = client.request(Method::GET, usage_url).send().await.ok()?;
+        let usage: serde_json::Value = usage_res.json().await.ok()?;
+
+        let parse_reset = |obj_key: &str| -> Option<i64> {
+            usage
+                .get(obj_key)
+                .and_then(|o| o.get("resets_at"))
+                .and_then(|v| v.as_str())
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.timestamp())
+        };
+
+        Some((
+            parse_reset("five_hour"),
+            parse_reset("seven_day"),
+            parse_reset("seven_day_opus"),
+        ))
     }
 
     fn local_count_tokens_response(body: &CreateMessageParams) -> axum::response::Response {

--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -12,7 +12,6 @@ use crate::{Args, config::ClewdrConfig};
 
 pub const CONFIG_NAME: &str = "clewdr.toml";
 pub const CLAUDE_ENDPOINT: &str = "https://api.anthropic.com";
-/// Anthropic console base, used for org usage introspection
 pub const CLAUDE_CONSOLE_ENDPOINT: &str = "https://console.anthropic.com";
 pub const GEMINI_ENDPOINT: &str = "https://generativelanguage.googleapis.com";
 pub const CC_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";

--- a/src/persistence/db/conn.rs
+++ b/src/persistence/db/conn.rs
@@ -110,6 +110,26 @@ async fn migrate(db: &DatabaseConnection) -> Result<(), ClewdrError> {
                 .big_integer()
                 .null(),
         )
+        .add_column(
+            ColumnDef::new(ColumnCookie::LifetimeUsage)
+                .string()
+                .null(),
+        )
+        .add_column(
+            ColumnDef::new(ColumnCookie::SessionUsage)
+                .string()
+                .null(),
+        )
+        .add_column(
+            ColumnDef::new(ColumnCookie::WeeklyUsage)
+                .string()
+                .null(),
+        )
+        .add_column(
+            ColumnDef::new(ColumnCookie::WeeklyOpusUsage)
+                .string()
+                .null(),
+        )
         .to_owned();
     db.execute(backend.build(&alter)).await.ok();
     Ok(())

--- a/src/persistence/db/entities.rs
+++ b/src/persistence/db/entities.rs
@@ -44,6 +44,7 @@ pub mod entity_cookie {
         pub supports_claude_1m: Option<bool>,
         #[sea_orm(nullable)]
         pub count_tokens_allowed: Option<bool>,
+        // Legacy token counters retained in DB but ignored by app
         #[sea_orm(column_type = "BigInteger", nullable)]
         pub total_input_tokens: Option<i64>,
         #[sea_orm(column_type = "BigInteger", nullable)]
@@ -52,6 +53,14 @@ pub mod entity_cookie {
         pub window_input_tokens: Option<i64>,
         #[sea_orm(column_type = "BigInteger", nullable)]
         pub window_output_tokens: Option<i64>,
+        #[sea_orm(nullable)]
+        pub session_usage: Option<String>,
+        #[sea_orm(nullable)]
+        pub weekly_usage: Option<String>,
+        #[sea_orm(nullable)]
+        pub weekly_opus_usage: Option<String>,
+        #[sea_orm(nullable)]
+        pub lifetime_usage: Option<String>,
     }
     #[derive(Copy, Clone, Debug, EnumIter)]
     pub enum Relation {}

--- a/src/router.rs
+++ b/src/router.rs
@@ -137,7 +137,7 @@ impl RouterBuilder {
             );
         let admin_router = Router::new()
             .route("/auth", get(api_auth))
-            .route("/config", get(api_get_config).put(api_post_config))
+            .route("/config", get(api_get_config).post(api_post_config))
             .route("/storage/import", post(api_storage_import))
             .route("/storage/export", post(api_storage_export))
             .route("/storage/status", get(api_storage_status));

--- a/src/services/sync.rs
+++ b/src/services/sync.rs
@@ -82,17 +82,7 @@ pub fn spawn(
             for u in db_invalid.iter() {
                 let key = u.cookie.to_string();
                 if !cur_inv.contains(&key) {
-                    let tmp = CookieStatus {
-                        cookie: u.cookie.clone(),
-                        token: None,
-                        reset_time: None,
-                        supports_claude_1m: None,
-                        count_tokens_allowed: None,
-                        total_input_tokens: 0,
-                        total_output_tokens: 0,
-                        window_input_tokens: 0,
-                        window_output_tokens: 0,
-                    };
+                    let tmp = CookieStatus { cookie: u.cookie.clone(), ..Default::default() };
                     let _ = c_handle.return_cookie(tmp, Some(u.reason.clone())).await;
                 }
             }


### PR DESCRIPTION
This pull request introduces a new, more granular breakdown of Claude cookie usage statistics by model family (Sonnet, Opus) across different usage periods, and decouples Vertex configuration management from the main Config page. It also improves the API and frontend error handling, and updates localization files for the new usage statistics. These changes enhance transparency for users regarding their token usage, prevent accidental loss of sensitive configuration, and streamline the configuration workflow.

**Cookie usage breakdown and visualization:**

* Adds a new `UsageBreakdown` structure to the backend and frontend, tracking input/output tokens per model family (Sonnet, Opus) for each usage window (session, 7-day, 7-day Opus, lifetime), and persists this data when DB persistence is enabled. [[1]](diffhunk://#diff-89d84952099d22ea96f21e9b7a4b2531e54ac67ac68ec97e0f576252a100f747R2-R20) [[2]](diffhunk://#diff-d1ecf7866169481c57ee662c6390aa2fcc5a2229e353337da00f1ae7c3ef05c0L392-R401) [[3]](diffhunk://#diff-d1ecf7866169481c57ee662c6390aa2fcc5a2229e353337da00f1ae7c3ef05c0R375-R380) [[4]](diffhunk://#diff-d1ecf7866169481c57ee662c6390aa2fcc5a2229e353337da00f1ae7c3ef05c0R412) [[5]](diffhunk://#diff-d1ecf7866169481c57ee662c6390aa2fcc5a2229e353337da00f1ae7c3ef05c0L439-R442)
* Updates the `CookieVisualization` React component to display per-family usage breakdowns for each quota window, showing Sonnet/Opus input/output when present.
* Adds new translation strings for Sonnet/Opus token statistics in both English and Chinese localization files. [[1]](diffhunk://#diff-a6916c1006782695d827d314f36c505fdfd8c99dfff19036f0d4ce039f626819L134-R144) [[2]](diffhunk://#diff-b6514896409b2b4b36bfb7f6163547aa225fa64758fe7ad4bdd4c564fb8133c4L134-R144)

**Configuration and API improvements:**

* Decouples Vertex credentials from the main Config page: Vertex config is no longer included in `/api/config` responses or updates, and is managed solely via the Gemini tab. The backend now always preserves existing Vertex configuration on config updates. [[1]](diffhunk://#diff-73d1488c1a3a1ec4a62c176011d3b4c640b69019470e905416589cdae44ff39aL31-R34) [[2]](diffhunk://#diff-73d1488c1a3a1ec4a62c176011d3b4c640b69019470e905416589cdae44ff39aL63-R67)
* Changes the Config update endpoint to use POST semantics, and improves error propagation so the UI displays backend error messages. The frontend now omits the `vertex` field from config updates to prevent accidental overwrites or type mismatches.

**Release notes and versioning:**

* Updates `RELEASE_NOTES.md` and bumps the crate version to `0.11.17` to document the new features and improvements, including the cookie usage breakdown and Vertex configuration changes. [[1]](diffhunk://#diff-68d24fa81558aae3d8c59e2aa57a4fa719ea3b04d7fa14beff45f16f00858f50L1-R21) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3)