### PR TITLE
fix: correct cookies usage parsing for float values (hotfix for PR#99)

### DIFF
--- a/src/api/misc.rs
+++ b/src/api/misc.rs
@@ -611,8 +611,9 @@ async fn fetch_usage_percent(
     let five = usage
         .get("five_hour")
         .and_then(|o| o.get("utilization"))
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
+        .and_then(|v| v.as_f64())
+        .map(|v| v.round() as u32)
+        .unwrap_or(0);
     let five_reset = usage
         .get("five_hour")
         .and_then(|o| o.get("resets_at"))
@@ -621,8 +622,9 @@ async fn fetch_usage_percent(
     let seven = usage
         .get("seven_day")
         .and_then(|o| o.get("utilization"))
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
+        .and_then(|v| v.as_f64())
+        .map(|v| v.round() as u32)
+        .unwrap_or(0);
     let seven_reset = usage
         .get("seven_day")
         .and_then(|o| o.get("resets_at"))
@@ -631,8 +633,8 @@ async fn fetch_usage_percent(
     let seven_opus = usage
         .get("seven_day_opus")
         .and_then(|o| o.get("utilization"))
-        .and_then(|v| v.as_u64())
-        .map(|v| v as u32)
+        .and_then(|v| v.as_f64())
+        .map(|v| v.round() as u32)
         .unwrap_or(0);
     let opus_reset = usage
         .get("seven_day_opus")


### PR DESCRIPTION
## Summary
Fix critical bug in PR#99 where cookie usage percentages always show 0%.

## Root Cause  
In PR#99's `fetch_usage_percent()` function at `src/api/misc.rs:614, 624, 634`, the code used `.as_u64()` to parse utilization values, but Anthropic's API returns floats (e.g., `5.0`, `36.0`, `23.0`), causing `.as_u64()` to return `None` and defaulting all values to 0.

## Changes
- **Fix**: Parse utilization as `f64` instead of `u64`
- Applied to three fields:
  - `five_hour.utilization`
  - `seven_day.utilization` 
  - `seven_day_opus.utilization`
- Use `.round()` to convert float to integer

## Code Change
```rust
// Before (incorrect)
.and_then(|v| v.as_u64())
.unwrap_or(0) as u32

// After (correct)
.and_then(|v| v.as_f64())
.map(|v| v.round() as u32)
.unwrap_or(0)
```

## Testing
- ✅ Tested with real Anthropic API responses
- ✅ Verified usage percentages display correctly
- ✅ Code compiles successfully

## Impact
- **Severity**: Critical - PR#99's main feature (usage tracking) was completely broken
- **Users affected**: All users using the `/api/cookies` cache feature from PR#99
- **Before fix**: All utilization values showed 0%
- **After fix**: Correctly displays actual percentages (5%, 36%, 23%, etc.)

## API Response Example
```json
{
  "five_hour": {"utilization": 5.0},
  "seven_day": {"utilization": 36.0},
  "seven_day_opus": {"utilization": 23.0}
}
```

Fixes the bug introduced in PR#99