### PR TITLE
处理Refresh token not found or invalid问题

### DIFF
--- a/src/claude_code_state/exchange.rs
+++ b/src/claude_code_state/exchange.rs
@@ -95,13 +95,11 @@ pub struct ExchangeResult {
 fn setup_client(cc_client_id: String) -> Result<ClaudeOauthClient, ClewdrError> {
     Ok(oauth2::basic::BasicClient::new(ClientId::new(cc_client_id))
         .set_auth_type(oauth2::AuthType::RequestBody)
-        .set_redirect_uri(
-            RedirectUrl::new(CC_REDIRECT_URI.as_str().to_string()).map_err(|_| {
-                ClewdrError::UnexpectedNone {
-                    msg: "Invalid redirect URI",
-                }
-            })?,
-        )
+        .set_redirect_uri(RedirectUrl::new(CC_REDIRECT_URI.clone()).map_err(|_| {
+            ClewdrError::UnexpectedNone {
+                msg: "Invalid redirect URI",
+            }
+        })?)
         .set_token_uri(TokenUrl::new(CC_TOKEN_URL.into()).map_err(|_| {
             ClewdrError::UnexpectedNone {
                 msg: "Invalid token URI",


### PR DESCRIPTION
捕获 invalid_grant 错误（Refresh token not found or invalid），清除旧 token，重新执行完整的 OAuth2 流程，并为oath2流程加上账号类型判断（调用get_organization()，判断是否是pro以上）