### PR TITLE
fix: convert OAI ImageUrl to Claude Image format in CC proxy

### DIFF
--- a/src/claude_web_state/transform.rs
+++ b/src/claude_web_state/transform.rs
@@ -66,7 +66,7 @@ impl ClaudeWebState {
                     })
                     .ok()?;
                 // choose the file name based on the media type (extract main type before any params)
-                let main_type = img.media_type.split(';').next().unwrap_or(&img.media_type);
+                let main_type = media_type.split(';').next().unwrap_or(&media_type);
                 let file_name = match main_type.to_lowercase().as_str() {
                     "image/png" => "image.png",
                     "image/jpeg" => "image.jpg",
@@ -170,7 +170,7 @@ fn merge_messages(msgs: Vec<Message>, system: String) -> Option<Merged> {
                                     imgs.push(source);
                                 }
                                 ImageSource::Url { url } => {
-                                    if let Some(source) = extract_image_from_url(&url) {
+                                    if let Some(source) = ImageSource::from_data_url(&url) {
                                         imgs.push(source);
                                     } else {
                                         warn!("Unsupported image url source");
@@ -266,4 +266,3 @@ fn merge_system(sys: Value) -> String {
         _ => String::new(),
     }
 }
-

--- a/src/types/claude.rs
+++ b/src/types/claude.rs
@@ -444,32 +444,54 @@ pub enum ImageSource {
 }
 
 impl ImageSource {
+    fn normalize_image_media_type(media_type: &str) -> Option<&'static str> {
+        match media_type.trim().to_lowercase().as_str() {
+            "image/jpeg" | "image/jpg" => Some("image/jpeg"),
+            "image/png" => Some("image/png"),
+            "image/gif" => Some("image/gif"),
+            "image/webp" => Some("image/webp"),
+            _ => None,
+        }
+    }
+
     /// Parse a data URI into an ImageSource
     /// Supports format: data:<media_type>[;params];base64,<data>
     /// e.g., data:image/png;base64,iVBORw0KGgo...
     /// e.g., data:image/png;name=foo;base64,iVBORw0KGgo...
     pub fn from_data_url(url: &str) -> Option<Self> {
-        if !url.starts_with("data:") {
-            return None;
-        }
+        let url = url.trim();
         let (metadata, base64_data) = url.split_once(',')?;
         // reject empty data
         if base64_data.is_empty() {
             return None;
         }
-        let after_data = metadata.strip_prefix("data:")?;
-        // find the last ";base64" marker (case-insensitive)
-        let lower = after_data.to_lowercase();
-        let base64_pos = lower.rfind(";base64")?;
-        let media_type = &after_data[..base64_pos];
-        // reject empty media type
-        if media_type.is_empty() {
+        if metadata.len() < 5 || !metadata[..5].eq_ignore_ascii_case("data:") {
+            return None;
+        }
+        let after_data = &metadata[5..];
+        let mut parts = after_data.split(';');
+        let media_type = Self::normalize_image_media_type(parts.next()?)?;
+        if !parts.any(|part| part.eq_ignore_ascii_case("base64")) {
             return None;
         }
 
         Some(Self::Base64 {
             media_type: media_type.to_string(),
             data: base64_data.to_owned(),
+        })
+    }
+
+    /// Parse an OpenAI-compatible image URL into an ImageSource.
+    pub fn from_image_url(url: &str) -> Option<Self> {
+        let url = url.trim();
+        Self::from_data_url(url).or_else(|| {
+            if url.starts_with("https://") || url.starts_with("http://") {
+                Some(Self::Url {
+                    url: url.to_string(),
+                })
+            } else {
+                None
+            }
         })
     }
 }

--- a/src/types/claude.rs
+++ b/src/types/claude.rs
@@ -467,8 +467,7 @@ impl ImageSource {
             return None;
         }
 
-        Some(Self {
-            type_: "base64".to_string(),
+        Some(Self::Base64 {
             media_type: media_type.to_string(),
             data: base64_data.to_owned(),
         })

--- a/src/types/oai.rs
+++ b/src/types/oai.rs
@@ -11,7 +11,10 @@ fn normalize_block(block: ContentBlock) -> Option<ContentBlock> {
         ContentBlock::Text { .. } => Some(block),
         ContentBlock::Image { .. } => Some(block),
         ContentBlock::ImageUrl { image_url } => {
-            ImageSource::from_data_url(&image_url.url).map(|source| ContentBlock::Image { source })
+            ImageSource::from_data_url(&image_url.url).map(|source| ContentBlock::Image {
+                source,
+                cache_control: None,
+            })
         }
         _ => Some(block),
     }

--- a/src/types/oai.rs
+++ b/src/types/oai.rs
@@ -11,7 +11,7 @@ fn normalize_block(block: ContentBlock) -> Option<ContentBlock> {
         ContentBlock::Text { .. } => Some(block),
         ContentBlock::Image { .. } => Some(block),
         ContentBlock::ImageUrl { image_url } => {
-            ImageSource::from_data_url(&image_url.url).map(|source| ContentBlock::Image {
+            ImageSource::from_image_url(&image_url.url).map(|source| ContentBlock::Image {
                 source,
                 cache_control: None,
             })
@@ -55,7 +55,6 @@ impl From<CreateMessageParams> for ClaudeCreateMessageParams {
             .messages
             .into_iter()
             .partition(|m| m.role == Role::System);
-        // normalize system blocks (convert ImageUrl to Image)
         let systems = systems
             .into_iter()
             .map(|m| m.content)
@@ -63,8 +62,7 @@ impl From<CreateMessageParams> for ClaudeCreateMessageParams {
                 MessageContent::Text { content } => vec![ContentBlock::text(content)],
                 MessageContent::Blocks { content } => content,
             })
-            .filter_map(normalize_block)
-            .filter(|b| matches!(b, ContentBlock::Text { .. } | ContentBlock::Image { .. }))
+            .filter(|b| matches!(b, ContentBlock::Text { .. }))
             .map(|b| json!(b))
             .collect::<Vec<_>>();
         let system = (!systems.is_empty()).then(|| json!(systems));

--- a/tests/image_conversion_test.rs
+++ b/tests/image_conversion_test.rs
@@ -1,0 +1,312 @@
+//! Tests for OAI ImageUrl to Claude Image format conversion
+//!
+//! This test suite validates that OpenAI format image_url blocks are correctly
+//! converted to Claude's image format with proper source structure.
+//!
+//! ## Background
+//! OpenAI uses `image_url: { url: "data:image/png;base64,..." }` format
+//! Claude uses `image: { source: { type: "base64", media_type: "image/png", data: "..." } }`
+//!
+//! ## Fixed Issues
+//! - CC proxy was passing ImageUrl directly to Claude API, causing 400/422 errors
+//! - System messages with images were being filtered out
+
+#[cfg(test)]
+mod tests {
+    use clewdr::types::claude::{
+        ContentBlock, ImageSource, ImageUrl, Message, MessageContent, Role,
+    };
+    use clewdr::types::oai::CreateMessageParams as OaiCreateMessageParams;
+    use clewdr::types::claude::CreateMessageParams as ClaudeCreateMessageParams;
+
+    #[test]
+    fn test_image_source_from_data_url_png() {
+        let url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+        let source = ImageSource::from_data_url(url);
+        assert!(source.is_some(), "Should parse valid PNG data URI");
+
+        let source = source.unwrap();
+        assert_eq!(source.type_, "base64");
+        assert_eq!(source.media_type, "image/png");
+        assert_eq!(source.data, "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
+    }
+
+    #[test]
+    fn test_image_source_from_data_url_jpeg() {
+        let url = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBg==";
+
+        let source = ImageSource::from_data_url(url);
+        assert!(source.is_some(), "Should parse valid JPEG data URI");
+
+        let source = source.unwrap();
+        assert_eq!(source.type_, "base64");
+        assert_eq!(source.media_type, "image/jpeg");
+        assert_eq!(source.data, "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBg==");
+    }
+
+    #[test]
+    fn test_image_source_from_data_url_webp() {
+        let url = "data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=";
+
+        let source = ImageSource::from_data_url(url);
+        assert!(source.is_some(), "Should parse valid WebP data URI");
+
+        let source = source.unwrap();
+        assert_eq!(source.type_, "base64");
+        assert_eq!(source.media_type, "image/webp");
+    }
+
+    #[test]
+    fn test_image_source_from_data_url_rejects_http() {
+        let url = "https://example.com/image.png";
+
+        let source = ImageSource::from_data_url(url);
+        assert!(source.is_none(), "Should reject HTTP URL");
+    }
+
+    #[test]
+    fn test_image_source_from_data_url_rejects_invalid() {
+        // Missing data: prefix
+        assert!(ImageSource::from_data_url("image/png;base64,abc").is_none());
+
+        // Missing comma separator
+        assert!(ImageSource::from_data_url("data:image/png;base64").is_none());
+
+        // Missing semicolon (no ;base64 marker)
+        assert!(ImageSource::from_data_url("data:image/pngbase64,abc").is_none());
+
+        // Empty string
+        assert!(ImageSource::from_data_url("").is_none());
+
+        // Empty data after comma
+        assert!(ImageSource::from_data_url("data:image/png;base64,").is_none());
+
+        // Empty media type
+        assert!(ImageSource::from_data_url("data:;base64,abc").is_none());
+    }
+
+    #[test]
+    fn test_image_source_from_data_url_with_extra_params() {
+        // data URI with extra parameters before base64
+        let url = "data:image/png;name=test.png;base64,iVBORw0KGgo=";
+
+        let source = ImageSource::from_data_url(url);
+        assert!(source.is_some(), "Should parse data URI with extra params");
+
+        let source = source.unwrap();
+        assert_eq!(source.type_, "base64");
+        assert_eq!(source.media_type, "image/png;name=test.png");
+        assert_eq!(source.data, "iVBORw0KGgo=");
+    }
+
+    #[test]
+    fn test_image_source_from_data_url_case_insensitive() {
+        // uppercase BASE64
+        let url = "data:image/png;BASE64,iVBORw0KGgo=";
+
+        let source = ImageSource::from_data_url(url);
+        assert!(source.is_some(), "Should parse uppercase BASE64");
+
+        let source = source.unwrap();
+        assert_eq!(source.type_, "base64");
+        assert_eq!(source.media_type, "image/png");
+
+        // mixed case Base64
+        let url2 = "data:image/jpeg;Base64,/9j/4AAQ=";
+        let source2 = ImageSource::from_data_url(url2);
+        assert!(source2.is_some(), "Should parse mixed case Base64");
+        assert_eq!(source2.unwrap().type_, "base64");
+    }
+
+    #[test]
+    fn test_oai_to_claude_conversion_with_image_url() {
+        // Create OAI format request with ImageUrl
+        let oai_params = OaiCreateMessageParams {
+            model: "claude-3-opus".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: MessageContent::Blocks {
+                    content: vec![
+                        ContentBlock::Text {
+                            text: "What's in this image?".to_string(),
+                        },
+                        ContentBlock::ImageUrl {
+                            image_url: ImageUrl {
+                                url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
+                            },
+                        },
+                    ],
+                },
+            }],
+            ..Default::default()
+        };
+
+        // Convert to Claude format
+        let claude_params: ClaudeCreateMessageParams = oai_params.into();
+
+        // Verify messages were converted
+        assert_eq!(claude_params.messages.len(), 1);
+
+        let msg = &claude_params.messages[0];
+        assert_eq!(msg.role, Role::User);
+
+        // Check content blocks
+        if let MessageContent::Blocks { content } = &msg.content {
+            assert_eq!(content.len(), 2);
+
+            // First block should be text
+            assert!(matches!(&content[0], ContentBlock::Text { text } if text == "What's in this image?"));
+
+            // Second block should be converted to Image (not ImageUrl)
+            match &content[1] {
+                ContentBlock::Image { source } => {
+                    assert_eq!(source.type_, "base64");
+                    assert_eq!(source.media_type, "image/png");
+                    assert_eq!(source.data, "iVBORw0KGgo=");
+                }
+                other => panic!("Expected Image block, got {:?}", other),
+            }
+        } else {
+            panic!("Expected Blocks content");
+        }
+    }
+
+    #[test]
+    fn test_oai_to_claude_conversion_filters_invalid_image_url() {
+        // Create OAI format request with invalid ImageUrl (http URL)
+        let oai_params = OaiCreateMessageParams {
+            model: "claude-3-opus".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: MessageContent::Blocks {
+                    content: vec![
+                        ContentBlock::Text {
+                            text: "What's in this image?".to_string(),
+                        },
+                        ContentBlock::ImageUrl {
+                            image_url: ImageUrl {
+                                url: "https://example.com/image.png".to_string(),
+                            },
+                        },
+                    ],
+                },
+            }],
+            ..Default::default()
+        };
+
+        // Convert to Claude format
+        let claude_params: ClaudeCreateMessageParams = oai_params.into();
+
+        // Verify only text block remains (invalid image URL should be filtered)
+        if let MessageContent::Blocks { content } = &claude_params.messages[0].content {
+            assert_eq!(content.len(), 1, "Invalid ImageUrl should be filtered out");
+            assert!(matches!(&content[0], ContentBlock::Text { .. }));
+        }
+    }
+
+    #[test]
+    fn test_oai_to_claude_preserves_existing_image_format() {
+        // Create request with Claude's native Image format
+        let oai_params = OaiCreateMessageParams {
+            model: "claude-3-opus".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: MessageContent::Blocks {
+                    content: vec![ContentBlock::Image {
+                        source: ImageSource {
+                            type_: "base64".to_string(),
+                            media_type: "image/png".to_string(),
+                            data: "existing_data".to_string(),
+                        },
+                    }],
+                },
+            }],
+            ..Default::default()
+        };
+
+        // Convert to Claude format
+        let claude_params: ClaudeCreateMessageParams = oai_params.into();
+
+        // Verify Image block is preserved as-is
+        if let MessageContent::Blocks { content } = &claude_params.messages[0].content {
+            match &content[0] {
+                ContentBlock::Image { source } => {
+                    assert_eq!(source.data, "existing_data");
+                }
+                other => panic!("Expected Image block, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn test_oai_to_claude_text_content_unchanged() {
+        // Create simple text request
+        let oai_params = OaiCreateMessageParams {
+            model: "claude-3-opus".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: MessageContent::Text {
+                    content: "Hello, world!".to_string(),
+                },
+            }],
+            ..Default::default()
+        };
+
+        // Convert to Claude format
+        let claude_params: ClaudeCreateMessageParams = oai_params.into();
+
+        // Verify text content is unchanged
+        if let MessageContent::Text { content } = &claude_params.messages[0].content {
+            assert_eq!(content, "Hello, world!");
+        } else {
+            panic!("Expected Text content");
+        }
+    }
+
+    #[test]
+    fn test_oai_to_claude_empty_message_filtered() {
+        // Create request with only invalid ImageUrl (will be filtered, leaving empty message)
+        let oai_params = OaiCreateMessageParams {
+            model: "claude-3-opus".to_string(),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: MessageContent::Text {
+                        content: "First message".to_string(),
+                    },
+                },
+                Message {
+                    role: Role::User,
+                    content: MessageContent::Blocks {
+                        content: vec![ContentBlock::ImageUrl {
+                            image_url: ImageUrl {
+                                url: "https://invalid.com/image.png".to_string(),
+                            },
+                        }],
+                    },
+                },
+                Message {
+                    role: Role::User,
+                    content: MessageContent::Text {
+                        content: "Third message".to_string(),
+                    },
+                },
+            ],
+            ..Default::default()
+        };
+
+        // Convert to Claude format
+        let claude_params: ClaudeCreateMessageParams = oai_params.into();
+
+        // Empty message should be filtered out, only 2 messages remain
+        assert_eq!(claude_params.messages.len(), 2);
+
+        if let MessageContent::Text { content } = &claude_params.messages[0].content {
+            assert_eq!(content, "First message");
+        }
+        if let MessageContent::Text { content } = &claude_params.messages[1].content {
+            assert_eq!(content, "Third message");
+        }
+    }
+}

--- a/tests/image_conversion_test.rs
+++ b/tests/image_conversion_test.rs
@@ -9,15 +9,14 @@
 //!
 //! ## Fixed Issues
 //! - CC proxy was passing ImageUrl directly to Claude API, causing 400/422 errors
-//! - System messages with images were being filtered out
 
 #[cfg(test)]
 mod tests {
+    use clewdr::types::claude::CreateMessageParams as ClaudeCreateMessageParams;
     use clewdr::types::claude::{
         ContentBlock, ImageSource, ImageUrl, Message, MessageContent, Role,
     };
     use clewdr::types::oai::CreateMessageParams as OaiCreateMessageParams;
-    use clewdr::types::claude::CreateMessageParams as ClaudeCreateMessageParams;
 
     #[test]
     fn test_image_source_from_data_url_png() {
@@ -29,7 +28,10 @@ mod tests {
         match source.unwrap() {
             ImageSource::Base64 { media_type, data } => {
                 assert_eq!(media_type, "image/png");
-                assert_eq!(data, "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
+                assert_eq!(
+                    data,
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                );
             }
             other => panic!("Expected Base64 image source, got {:?}", other),
         }
@@ -103,11 +105,30 @@ mod tests {
 
         match source.unwrap() {
             ImageSource::Base64 { media_type, data } => {
-                assert_eq!(media_type, "image/png;name=test.png");
+                assert_eq!(media_type, "image/png");
                 assert_eq!(data, "iVBORw0KGgo=");
             }
             other => panic!("Expected Base64 image source, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_image_source_from_data_url_normalizes_jpg() {
+        let url = "data:image/jpg;base64,/9j/4AAQ=";
+
+        let source = ImageSource::from_data_url(url);
+
+        match source.unwrap() {
+            ImageSource::Base64 { media_type, .. } => assert_eq!(media_type, "image/jpeg"),
+            other => panic!("Expected Base64 image source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_image_source_from_data_url_rejects_unsupported_media_type() {
+        let url = "data:application/pdf;base64,JVBERi0xLjQK";
+
+        assert!(ImageSource::from_data_url(url).is_none());
     }
 
     #[test]
@@ -165,7 +186,9 @@ mod tests {
             assert_eq!(content.len(), 2);
 
             // First block should be text
-            assert!(matches!(&content[0], ContentBlock::Text { text, .. } if text == "What's in this image?"));
+            assert!(
+                matches!(&content[0], ContentBlock::Text { text, .. } if text == "What's in this image?")
+            );
 
             // Second block should be converted to Image (not ImageUrl)
             match &content[1] {
@@ -175,7 +198,7 @@ mod tests {
                         assert_eq!(data, "iVBORw0KGgo=");
                     }
                     other => panic!("Expected Base64 image source, got {:?}", other),
-                }
+                },
                 other => panic!("Expected Image block, got {:?}", other),
             }
         } else {
@@ -184,8 +207,8 @@ mod tests {
     }
 
     #[test]
-    fn test_oai_to_claude_conversion_filters_invalid_image_url() {
-        // Create OAI format request with invalid ImageUrl (http URL)
+    fn test_oai_to_claude_conversion_with_remote_image_url() {
+        // Create OAI format request with remote ImageUrl
         let oai_params = OaiCreateMessageParams {
             model: "claude-3-opus".to_string(),
             messages: vec![Message {
@@ -207,7 +230,41 @@ mod tests {
         // Convert to Claude format
         let claude_params: ClaudeCreateMessageParams = oai_params.into();
 
-        // Verify only text block remains (invalid image URL should be filtered)
+        if let MessageContent::Blocks { content } = &claude_params.messages[0].content {
+            assert_eq!(content.len(), 2);
+            assert!(matches!(&content[0], ContentBlock::Text { .. }));
+            assert!(matches!(
+                &content[1],
+                ContentBlock::Image {
+                    source: ImageSource::Url { url },
+                    ..
+                } if url == "https://example.com/image.png"
+            ));
+        }
+    }
+
+    #[test]
+    fn test_oai_to_claude_conversion_filters_invalid_image_url() {
+        let oai_params = OaiCreateMessageParams {
+            model: "claude-3-opus".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: MessageContent::Blocks {
+                    content: vec![
+                        ContentBlock::text("What's in this image?"),
+                        ContentBlock::ImageUrl {
+                            image_url: ImageUrl {
+                                url: "not-a-url".to_string(),
+                            },
+                        },
+                    ],
+                },
+            }],
+            ..Default::default()
+        };
+
+        let claude_params: ClaudeCreateMessageParams = oai_params.into();
+
         if let MessageContent::Blocks { content } = &claude_params.messages[0].content {
             assert_eq!(content.len(), 1, "Invalid ImageUrl should be filtered out");
             assert!(matches!(&content[0], ContentBlock::Text { .. }));
@@ -241,7 +298,9 @@ mod tests {
         if let MessageContent::Blocks { content } = &claude_params.messages[0].content {
             match &content[0] {
                 ContentBlock::Image { source, .. } => {
-                    assert!(matches!(source, ImageSource::Base64 { data, .. } if data == "existing_data"));
+                    assert!(
+                        matches!(source, ImageSource::Base64 { data, .. } if data == "existing_data")
+                    );
                 }
                 other => panic!("Expected Image block, got {:?}", other),
             }
@@ -290,7 +349,7 @@ mod tests {
                     content: MessageContent::Blocks {
                         content: vec![ContentBlock::ImageUrl {
                             image_url: ImageUrl {
-                                url: "https://invalid.com/image.png".to_string(),
+                                url: "not-a-url".to_string(),
                             },
                         }],
                     },
@@ -317,5 +376,42 @@ mod tests {
         if let MessageContent::Text { content } = &claude_params.messages[1].content {
             assert_eq!(content, "Third message");
         }
+    }
+
+    #[test]
+    fn test_oai_to_claude_system_content_keeps_only_text() {
+        let oai_params = OaiCreateMessageParams {
+            model: "claude-3-opus".to_string(),
+            messages: vec![
+                Message {
+                    role: Role::System,
+                    content: MessageContent::Blocks {
+                        content: vec![
+                            ContentBlock::text("System prompt"),
+                            ContentBlock::ImageUrl {
+                                image_url: ImageUrl {
+                                    url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
+                                },
+                            },
+                        ],
+                    },
+                },
+                Message {
+                    role: Role::User,
+                    content: MessageContent::Text {
+                        content: "Hello".to_string(),
+                    },
+                },
+            ],
+            ..Default::default()
+        };
+
+        let claude_params: ClaudeCreateMessageParams = oai_params.into();
+        let system = claude_params.system.expect("system should be present");
+        let blocks = system.as_array().expect("system should be an array");
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(blocks[0]["text"], "System prompt");
     }
 }

--- a/tests/image_conversion_test.rs
+++ b/tests/image_conversion_test.rs
@@ -26,10 +26,13 @@ mod tests {
         let source = ImageSource::from_data_url(url);
         assert!(source.is_some(), "Should parse valid PNG data URI");
 
-        let source = source.unwrap();
-        assert_eq!(source.type_, "base64");
-        assert_eq!(source.media_type, "image/png");
-        assert_eq!(source.data, "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
+        match source.unwrap() {
+            ImageSource::Base64 { media_type, data } => {
+                assert_eq!(media_type, "image/png");
+                assert_eq!(data, "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
+            }
+            other => panic!("Expected Base64 image source, got {:?}", other),
+        }
     }
 
     #[test]
@@ -39,10 +42,13 @@ mod tests {
         let source = ImageSource::from_data_url(url);
         assert!(source.is_some(), "Should parse valid JPEG data URI");
 
-        let source = source.unwrap();
-        assert_eq!(source.type_, "base64");
-        assert_eq!(source.media_type, "image/jpeg");
-        assert_eq!(source.data, "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBg==");
+        match source.unwrap() {
+            ImageSource::Base64 { media_type, data } => {
+                assert_eq!(media_type, "image/jpeg");
+                assert_eq!(data, "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBg==");
+            }
+            other => panic!("Expected Base64 image source, got {:?}", other),
+        }
     }
 
     #[test]
@@ -52,9 +58,10 @@ mod tests {
         let source = ImageSource::from_data_url(url);
         assert!(source.is_some(), "Should parse valid WebP data URI");
 
-        let source = source.unwrap();
-        assert_eq!(source.type_, "base64");
-        assert_eq!(source.media_type, "image/webp");
+        match source.unwrap() {
+            ImageSource::Base64 { media_type, .. } => assert_eq!(media_type, "image/webp"),
+            other => panic!("Expected Base64 image source, got {:?}", other),
+        }
     }
 
     #[test]
@@ -94,10 +101,13 @@ mod tests {
         let source = ImageSource::from_data_url(url);
         assert!(source.is_some(), "Should parse data URI with extra params");
 
-        let source = source.unwrap();
-        assert_eq!(source.type_, "base64");
-        assert_eq!(source.media_type, "image/png;name=test.png");
-        assert_eq!(source.data, "iVBORw0KGgo=");
+        match source.unwrap() {
+            ImageSource::Base64 { media_type, data } => {
+                assert_eq!(media_type, "image/png;name=test.png");
+                assert_eq!(data, "iVBORw0KGgo=");
+            }
+            other => panic!("Expected Base64 image source, got {:?}", other),
+        }
     }
 
     #[test]
@@ -108,15 +118,16 @@ mod tests {
         let source = ImageSource::from_data_url(url);
         assert!(source.is_some(), "Should parse uppercase BASE64");
 
-        let source = source.unwrap();
-        assert_eq!(source.type_, "base64");
-        assert_eq!(source.media_type, "image/png");
+        match source.unwrap() {
+            ImageSource::Base64 { media_type, .. } => assert_eq!(media_type, "image/png"),
+            other => panic!("Expected Base64 image source, got {:?}", other),
+        }
 
         // mixed case Base64
         let url2 = "data:image/jpeg;Base64,/9j/4AAQ=";
         let source2 = ImageSource::from_data_url(url2);
         assert!(source2.is_some(), "Should parse mixed case Base64");
-        assert_eq!(source2.unwrap().type_, "base64");
+        assert!(matches!(source2.unwrap(), ImageSource::Base64 { .. }));
     }
 
     #[test]
@@ -128,9 +139,7 @@ mod tests {
                 role: Role::User,
                 content: MessageContent::Blocks {
                     content: vec![
-                        ContentBlock::Text {
-                            text: "What's in this image?".to_string(),
-                        },
+                        ContentBlock::text("What's in this image?"),
                         ContentBlock::ImageUrl {
                             image_url: ImageUrl {
                                 url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
@@ -156,14 +165,16 @@ mod tests {
             assert_eq!(content.len(), 2);
 
             // First block should be text
-            assert!(matches!(&content[0], ContentBlock::Text { text } if text == "What's in this image?"));
+            assert!(matches!(&content[0], ContentBlock::Text { text, .. } if text == "What's in this image?"));
 
             // Second block should be converted to Image (not ImageUrl)
             match &content[1] {
-                ContentBlock::Image { source } => {
-                    assert_eq!(source.type_, "base64");
-                    assert_eq!(source.media_type, "image/png");
-                    assert_eq!(source.data, "iVBORw0KGgo=");
+                ContentBlock::Image { source, .. } => match source {
+                    ImageSource::Base64 { media_type, data } => {
+                        assert_eq!(media_type, "image/png");
+                        assert_eq!(data, "iVBORw0KGgo=");
+                    }
+                    other => panic!("Expected Base64 image source, got {:?}", other),
                 }
                 other => panic!("Expected Image block, got {:?}", other),
             }
@@ -181,9 +192,7 @@ mod tests {
                 role: Role::User,
                 content: MessageContent::Blocks {
                     content: vec![
-                        ContentBlock::Text {
-                            text: "What's in this image?".to_string(),
-                        },
+                        ContentBlock::text("What's in this image?"),
                         ContentBlock::ImageUrl {
                             image_url: ImageUrl {
                                 url: "https://example.com/image.png".to_string(),
@@ -214,11 +223,11 @@ mod tests {
                 role: Role::User,
                 content: MessageContent::Blocks {
                     content: vec![ContentBlock::Image {
-                        source: ImageSource {
-                            type_: "base64".to_string(),
+                        source: ImageSource::Base64 {
                             media_type: "image/png".to_string(),
                             data: "existing_data".to_string(),
                         },
+                        cache_control: None,
                     }],
                 },
             }],
@@ -231,8 +240,8 @@ mod tests {
         // Verify Image block is preserved as-is
         if let MessageContent::Blocks { content } = &claude_params.messages[0].content {
             match &content[0] {
-                ContentBlock::Image { source } => {
-                    assert_eq!(source.data, "existing_data");
+                ContentBlock::Image { source, .. } => {
+                    assert!(matches!(source, ImageSource::Base64 { data, .. } if data == "existing_data"));
                 }
                 other => panic!("Expected Image block, got {:?}", other),
             }


### PR DESCRIPTION
## Summary

- Fix OpenAI-compatible `image_url` handling in the `/code/v1` path
- Convert OpenAI `image_url` content blocks into Claude `image` blocks
- Support both base64 data URLs and remote `http(s)` image URLs
- Normalize and validate image media types before sending them to Claude
- Keep system content text-only to match the Claude Messages API shape
- Add regression tests for data URLs, remote URLs, invalid URLs, and system content handling

## Problem

The `/code/v1` endpoint accepts OpenAI-compatible message content, including blocks like:

```json
{
  "type": "image_url",
  "image_url": {
    "url": "data:image/png;base64,..."
  }
}
```

Claude expects image content to use its native `image` block with a `source` object. Without converting the OpenAI shape first, image content can be ignored or forwarded in an unsupported format.

## Changes

- Add image URL normalization for OpenAI-compatible content blocks
- Convert base64 data URLs into Claude `ImageSource::Base64`
- Convert remote `http(s)` URLs into Claude `ImageSource::Url`
- Normalize `image/jpg` to `image/jpeg`
- Strip data URI parameters such as `;name=...` from `media_type`
- Reject unsupported media types such as `application/pdf` for image blocks
- Preserve existing Claude-native image blocks unchanged
- Keep system messages text-only instead of converting image blocks into the top-level Claude `system` field
- Add focused tests for the conversion behavior

## Test plan

- [x] `cargo test --test image_conversion_test`
- [x] `cargo test --all-targets`
- [x] `git diff --check`

## Notes

The Docker image publish checks may fail on PRs because the workflow tries to push to GHCR and receives:

```text
denied: installation not allowed to Write organization package
```

The binary build matrix passes, so this appears to be a package publishing permission issue rather than a code issue.