### PR TITLE
feat: improve Claude Code CLI compatibility and add health endpoints

### DIFF
--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -9,4 +9,4 @@
 mod auth;
 pub mod claude;
 
-pub use auth::{RequireAdminAuth, RequireBearerAuth, RequireXApiKeyAuth};
+pub use auth::{RequireAdminAuth, RequireBearerAuth, RequireFlexibleAuth, RequireXApiKeyAuth};

--- a/src/router.rs
+++ b/src/router.rs
@@ -10,7 +10,7 @@ use tower_http::{compression::CompressionLayer, cors::CorsLayer};
 use crate::{
     api::*,
     middleware::{
-        RequireAdminAuth, RequireBearerAuth, RequireXApiKeyAuth,
+        RequireAdminAuth, RequireBearerAuth, RequireFlexibleAuth, RequireXApiKeyAuth,
         claude::{add_usage_info, apply_stop_sequences, check_overloaded, to_oai},
     },
     providers::claude::ClaudeProviders,
@@ -82,7 +82,7 @@ impl RouterBuilder {
             )
             .layer(
                 ServiceBuilder::new()
-                    .layer(from_extractor::<RequireXApiKeyAuth>())
+                    .layer(from_extractor::<RequireFlexibleAuth>())
                     .layer(CompressionLayer::new()),
             )
             .with_state(self.claude_providers.code());


### PR DESCRIPTION
## Summary

This PR improves compatibility with Claude Code CLI and adds health check endpoints.

### Background

Claude Code CLI uses `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` for authentication. The standard endpoint format is `{base_url}/v1/messages`, where base_url typically ends with `/code` (e.g., `http://host:8484/code`).

### Changes

**1. Add `RequireFlexibleAuth` middleware**
- Accepts both `x-api-key` header and `Authorization: Bearer` token
- Claude Code CLI sends auth via Bearer token (from `ANTHROPIC_AUTH_TOKEN`)
- Other clients (like SillyTavern) may use `x-api-key` header
- This ensures maximum compatibility with different client implementations

**2. Add health check endpoints (`/code` and `/health`)**
- `/code` endpoint: Required for connectivity testing tools like cc-switch which test the base URL directly
- `/health` endpoint: Required for Docker healthcheck and monitoring tools
- Both return `{"status": "ok", "version": "..."}` without authentication, as health probes typically don't carry credentials

## Test Plan

- [x] Verified `/code` returns 200 with status JSON
- [x] Verified `/health` returns 200 with status JSON
- [x] Verified cc-switch speedtest now passes
- [x] Verified Claude Code CLI can authenticate via Bearer token