### PR TITLE
fix: increase default body size limit to 32MB

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -1,5 +1,6 @@
 use axum::{
     Router,
+    extract::DefaultBodyLimit,
     http::Method,
     middleware::{from_extractor, map_response},
     routing::{delete, get, post},
@@ -198,5 +199,6 @@ impl RouterBuilder {
     /// Finalizes the router configuration for use with axum
     pub fn build(self) -> Router {
         self.inner
+            .layer(DefaultBodyLimit::max(32 * 1024 * 1024))
     }
 }


### PR DESCRIPTION
  ## Summary

  - Axum 默认请求体限制为 2MB，当 SillyTavern 发送包含较大或多个图片的请求时会返回 413 Payload Too Large
  - 通过添加 `DefaultBodyLimit` 中间件将全局请求体上限提高到 32MB

  ## Changes

  - `src/router.rs`: 导入 `DefaultBodyLimit`，在 `build()` 中应用 `.layer(DefaultBodyLimit::max(32 * 1024 * 1024))`