### PR TITLE
feat: add auto trigger CD on quota reset

### DIFF
--- a/frontend/src/components/config/ConfigForm.tsx
+++ b/frontend/src/components/config/ConfigForm.tsx
@@ -146,6 +146,13 @@ const ConfigForm: React.FC<ConfigFormProps> = ({ config, onChange }) => {
             onChange={onChange}
             label={t("config.sections.api.sanitizeMessages")}
           />
+
+          <ConfigCheckbox
+            name="auto_trigger_cd"
+            checked={!!config.auto_trigger_cd}
+            onChange={onChange}
+            label={t("config.sections.api.autoTriggerCd")}
+          />
         </div>
       </ConfigSection>
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -152,7 +152,8 @@
         "preserveChats": "Preserve Chats",
         "webSearch": "Web Search",
         "webCountTokens": "Enable web count_tokens",
-        "sanitizeMessages": "Sanitize messages (trim whitespace)"
+        "sanitizeMessages": "Sanitize messages (trim whitespace)",
+        "autoTriggerCd": "Auto trigger cooldown on quota reset"
       },
       "cookie": {
         "title": "Cookie Settings",

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -152,7 +152,8 @@
         "preserveChats": "保留聊天",
         "webSearch": "网页搜索",
         "webCountTokens": "允许 Web 渠道调用 count_tokens",
-        "sanitizeMessages": "消息清理（去除空白）"
+        "sanitizeMessages": "消息清理（去除空白）",
+        "autoTriggerCd": "配额重置后自动触发冷却计时"
       },
       "cookie": {
         "title": "Cookie设置",

--- a/frontend/src/types/config.types.ts
+++ b/frontend/src/types/config.types.ts
@@ -21,6 +21,7 @@ export interface ConfigData {
   web_search: boolean;
   enable_web_count_tokens: boolean;
   sanitize_messages: boolean;
+  auto_trigger_cd: boolean;
 
   // Cookie settings
   skip_first_warning: boolean;

--- a/src/claude_code_state/chat.rs
+++ b/src/claude_code_state/chat.rs
@@ -228,6 +228,64 @@ impl ClaudeCodeState {
         }
     }
 
+    pub async fn trigger_cd(&mut self) -> Result<(), ClewdrError> {
+        match self.check_token() {
+            TokenStatus::None => {
+                let org = self.get_organization().await?;
+                let code = self.exchange_code(&org).await?;
+                self.exchange_token(code).await?;
+            }
+            TokenStatus::Expired => {
+                self.refresh_token().await?;
+            }
+            TokenStatus::Valid => {}
+        }
+
+        let access_token = self
+            .cookie
+            .as_ref()
+            .and_then(|c| c.token.as_ref())
+            .ok_or(ClewdrError::UnexpectedNone {
+                msg: "No access token available",
+            })?
+            .access_token
+            .to_owned();
+
+        let body = crate::types::claude::CreateMessageParams {
+            max_tokens: 1,
+            messages: vec![crate::types::claude::Message {
+                role: crate::types::claude::Role::User,
+                content: crate::types::claude::MessageContent::Text {
+                    content: "Hi".to_string(),
+                },
+            }],
+            model: "claude-haiku-4-5-20251001".to_string(),
+            stream: Some(false),
+            container: None,
+            context_management: None,
+            mcp_servers: None,
+            system: None,
+            temperature: None,
+            stop_sequences: None,
+            thinking: None,
+            top_k: None,
+            top_p: None,
+            tools: None,
+            tool_choice: None,
+            metadata: None,
+            output_config: None,
+            output_format: None,
+            service_tier: None,
+            n: None,
+        };
+
+        let resp = self.execute_claude_request(&access_token, &body, false).await;
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
     pub async fn fetch_usage_metrics(&mut self) -> Result<serde_json::Value, ClewdrError> {
         match self.check_token() {
             TokenStatus::None => {

--- a/src/config/clewdr_config.rs
+++ b/src/config/clewdr_config.rs
@@ -97,6 +97,8 @@ pub struct ClewdrConfig {
     pub enable_web_count_tokens: bool,
     #[serde(default)]
     pub sanitize_messages: bool,
+    #[serde(default)]
+    pub auto_trigger_cd: bool,
 
     // Cookie settings, can hot reload
     #[serde(default)]
@@ -156,6 +158,7 @@ impl Default for ClewdrConfig {
             web_search: false,
             enable_web_count_tokens: false,
             sanitize_messages: false,
+            auto_trigger_cd: false,
             skip_first_warning: false,
             skip_second_warning: false,
             skip_restricted: false,

--- a/src/router.rs
+++ b/src/router.rs
@@ -35,6 +35,7 @@ impl RouterBuilder {
         let cookie_handle = CookieActorHandle::start()
             .await
             .expect("Failed to start CookieActor");
+        crate::services::cd_scheduler::CdScheduler::spawn(cookie_handle.clone());
         let claude_providers = crate::providers::claude::build_providers(cookie_handle.clone());
         RouterBuilder {
             claude_providers,

--- a/src/services/cd_scheduler.rs
+++ b/src/services/cd_scheduler.rs
@@ -1,0 +1,194 @@
+use std::collections::HashMap;
+
+use chrono::Utc;
+use tracing::{info, warn};
+
+use crate::{
+    claude_code_state::ClaudeCodeState,
+    config::{CLEWDR_CONFIG, ClewdrCookie},
+    services::cookie_actor::CookieActorHandle,
+};
+
+const CD_CHECK_INTERVAL_SECS: u64 = 60;
+
+struct WindowState {
+    session: Option<i64>,
+    weekly: Option<i64>,
+    weekly_sonnet: Option<i64>,
+    weekly_opus: Option<i64>,
+    /// Whether we have already triggered CD for the current expired state.
+    /// Prevents duplicate triggers when re-fetch fails and we store expired timestamps.
+    triggered_for_current: bool,
+}
+
+pub struct CdScheduler;
+
+fn parse_resets_at(usage: &serde_json::Value, key: &str) -> Option<i64> {
+    usage
+        .get(key)
+        .and_then(|o| o.get("resets_at"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.timestamp())
+}
+
+/// Check if a window has expired since last check.
+/// Returns true only when the window transitions from "active" (future) to "expired" (past).
+fn window_expired_since_last_check(current: Option<i64>, previous: Option<i64>, now: i64) -> bool {
+    match (current, previous) {
+        // Same timestamp, was in the future, now expired
+        (Some(curr), Some(prev)) if curr == prev && now >= curr => true,
+        // Timestamp changed and the new one is also expired
+        (Some(curr), Some(prev)) if curr != prev && now >= curr => true,
+        _ => false,
+    }
+}
+
+impl CdScheduler {
+    pub fn spawn(handle: CookieActorHandle) {
+        tokio::spawn(async move {
+            let mut triggered: HashMap<ClewdrCookie, WindowState> = HashMap::new();
+            let mut interval =
+                tokio::time::interval(tokio::time::Duration::from_secs(CD_CHECK_INTERVAL_SECS));
+            loop {
+                interval.tick().await;
+                if !CLEWDR_CONFIG.load().auto_trigger_cd {
+                    continue;
+                }
+                Self::check_and_trigger(&handle, &mut triggered).await;
+            }
+        });
+    }
+
+    async fn check_and_trigger(
+        handle: &CookieActorHandle,
+        triggered: &mut HashMap<ClewdrCookie, WindowState>,
+    ) {
+        let status = match handle.get_status().await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("CD scheduler: failed to get cookie status: {}", e);
+                return;
+            }
+        };
+
+        let valid_keys: Vec<ClewdrCookie> =
+            status.valid.iter().map(|c| c.cookie.clone()).collect();
+
+        for cookie in status.valid.iter() {
+            Self::check_cookie(handle, triggered, cookie.clone()).await;
+        }
+
+        triggered.retain(|k, _| valid_keys.contains(k));
+    }
+
+    async fn check_cookie(
+        handle: &CookieActorHandle,
+        triggered: &mut HashMap<ClewdrCookie, WindowState>,
+        cookie: crate::config::CookieStatus,
+    ) {
+        let cookie_key = cookie.cookie.clone();
+        let display_key = cookie.cookie.ellipse();
+
+        let mut state = match ClaudeCodeState::from_cookie(handle.clone(), cookie) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    "CD scheduler: failed to create state for {}: {}",
+                    display_key, e
+                );
+                return;
+            }
+        };
+
+        let usage = match state.fetch_usage_metrics().await {
+            Ok(u) => u,
+            Err(e) => {
+                warn!(
+                    "CD scheduler: failed to fetch usage for {}: {}",
+                    display_key, e
+                );
+                return;
+            }
+        };
+
+        let now = Utc::now().timestamp();
+        let current = WindowState {
+            session: parse_resets_at(&usage, "five_hour"),
+            weekly: parse_resets_at(&usage, "seven_day"),
+            weekly_sonnet: parse_resets_at(&usage, "seven_day_sonnet"),
+            weekly_opus: parse_resets_at(&usage, "seven_day_opus"),
+            triggered_for_current: false,
+        };
+
+        let needs_trigger = if let Some(prev) = triggered.get(&cookie_key) {
+            // If we already triggered and timestamps haven't changed, skip
+            if prev.triggered_for_current && Self::same_timestamps(&current, prev) {
+                false
+            } else {
+                window_expired_since_last_check(current.session, prev.session, now)
+                    || window_expired_since_last_check(current.weekly, prev.weekly, now)
+                    || window_expired_since_last_check(
+                        current.weekly_sonnet,
+                        prev.weekly_sonnet,
+                        now,
+                    )
+                    || window_expired_since_last_check(current.weekly_opus, prev.weekly_opus, now)
+            }
+        } else {
+            // First time seeing this cookie.
+            // Only trigger if the session (five_hour) window has no active timer,
+            // meaning the cookie has never been used or its session window has expired.
+            // We intentionally check only session to avoid false positives from
+            // accounts that legitimately lack other window types.
+            current.session.map(|ts| now >= ts).unwrap_or(true)
+        };
+
+        if needs_trigger {
+            info!("CD scheduler: triggering CD for cookie {}...", display_key);
+            match state.trigger_cd().await {
+                Ok(_) => {
+                    info!(
+                        "CD scheduler: trigger sent successfully for {}",
+                        display_key
+                    );
+                }
+                Err(e) => {
+                    warn!("CD scheduler: trigger failed for {}: {}", display_key, e);
+                }
+            }
+            // Re-fetch usage to get updated timestamps after trigger
+            if let Ok(new_usage) = state.fetch_usage_metrics().await {
+                let new_state = WindowState {
+                    session: parse_resets_at(&new_usage, "five_hour"),
+                    weekly: parse_resets_at(&new_usage, "seven_day"),
+                    weekly_sonnet: parse_resets_at(&new_usage, "seven_day_sonnet"),
+                    weekly_opus: parse_resets_at(&new_usage, "seven_day_opus"),
+                    // If timestamps are still expired after trigger, mark as triggered
+                    // to prevent duplicate. Will reset when new future timestamps appear.
+                    triggered_for_current: true,
+                };
+                triggered.insert(cookie_key, new_state);
+            } else {
+                // Re-fetch failed; mark as triggered to prevent duplicate on next tick
+                let mut fallback = current;
+                fallback.triggered_for_current = true;
+                triggered.insert(cookie_key, fallback);
+            }
+        } else {
+            triggered.insert(cookie_key, current);
+        }
+
+        // Do NOT call return_cookie — the cookie was obtained from a read-only
+        // get_status() snapshot, not borrowed from the actor. Returning it would
+        // overwrite concurrent updates (token refreshes, usage counters) made
+        // by real requests.
+    }
+
+    fn same_timestamps(a: &WindowState, b: &WindowState) -> bool {
+        a.session == b.session
+            && a.weekly == b.weekly
+            && a.weekly_sonnet == b.weekly_sonnet
+            && a.weekly_opus == b.weekly_opus
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod cd_scheduler;
 pub mod cookie_actor;
 #[cfg(feature = "portable")]
 pub mod update;


### PR DESCRIPTION
## Summary
  - Add `auto_trigger_cd` config option that automatically sends a minimal message to Claude API when quota resets,
  pre-starting the 5-hour cooldown timer to reduce wait time when quota is later exhausted
  - Trigger CD for cookies whose session/weekly quota windows expire, and freshly added cookies with no active session
  window
  - Use cheapest model (claude-haiku-4-5-20251001) with max_tokens=1 to minimize quota impact

  ## How it works
  Claude's 5h session quota timer starts from the **first message sent**, not when quota runs out. By sending a trigger
  message right when quota resets (or when a new cookie is added), the next 5h window starts immediately — reducing
  effective wait time from hours to minutes.

  ## Changes
  - `src/config/clewdr_config.rs`: Add `auto_trigger_cd` boolean config field (default: false)
  - `src/services/cd_scheduler.rs`: New independent background scheduler (60s polling) that detects expired quota
  windows via usage API and triggers CD 
  - `src/claude_code_state/chat.rs`: Add `trigger_cd()` method that authenticates and sends a minimal request
  - `src/router.rs`: Spawn scheduler after CookieActorHandle creation
  - `src/services/mod.rs`: Register new module
  - Frontend: Add `auto_trigger_cd` toggle in Config UI with en/zh translations