### PR TITLE
feat: add web endpoint fallback for cookie usage metrics on non-Claude-Code accounts

### DIFF
--- a/src/api/misc.rs
+++ b/src/api/misc.rs
@@ -21,6 +21,7 @@ use crate::{
     claude_code_state::ClaudeCodeState,
     config::{CLEWDR_CONFIG, CookieStatus},
     services::cookie_actor::CookieActorHandle,
+    claude_web_state::ClaudeWebState,
 };
 
 /// Cache entry for cookie status responses
@@ -383,29 +384,73 @@ async fn fetch_usage_percent(
     u32,
     Option<String>,
 )> {
-    let mut state = match ClaudeCodeState::from_cookie(handle, cookie.clone()) {
+    // 1) Try OAuth endpoint (works for Pro / Max with Claude Code Access)
+    let usage = match try_oauth_usage(&cookie, &handle).await {
+        Some(u) => u,
+        None => {
+            // 2) Fallback to claude.ai web endpoint (works for Enterprise)
+            info!(
+                "OAuth usage unavailable for {}, trying web fallback",
+                cookie.cookie
+            );
+            match ClaudeWebState::fetch_web_usage(handle, cookie.clone()).await {
+                Some(u) => u,
+                None => {
+                    warn!(
+                        "Web usage fallback also failed for {}",
+                        cookie.cookie
+                    );
+                    return None;
+                }
+            }
+        }
+    };
+
+    extract_usage_fields(&usage)
+}
+
+/// Try the OAuth endpoint (`api.anthropic.com/api/oauth/usage`)
+async fn try_oauth_usage(
+    cookie: &CookieStatus,
+    handle: &CookieActorHandle,
+) -> Option<serde_json::Value> {
+    let mut state = match ClaudeCodeState::from_cookie(handle.clone(), cookie.clone()) {
         Ok(s) => s,
         Err(e) => {
             warn!(
-                "fetch_usage_percent: from_cookie failed for {}: {}",
+                "try_oauth_usage: from_cookie failed for {}: {}",
                 cookie.cookie, e
             );
             return None;
         }
     };
-    let usage = match state.fetch_usage_metrics().await {
-        Ok(u) => u,
+    let result = state.fetch_usage_metrics().await;
+    state.return_cookie(None).await;
+    match result {
+        Ok(u) => Some(u),
         Err(e) => {
             warn!(
-                "fetch_usage_percent: fetch_usage_metrics failed for {}: {}",
+                "try_oauth_usage: fetch failed for {}: {}",
                 cookie.cookie, e
             );
-            state.return_cookie(None).await;
-            return None;
+            None
         }
-    };
-    state.return_cookie(None).await;
+    }
+}
 
+/// Extract the eight usage fields from the usage JSON returned by either endpoint
+fn extract_usage_fields(
+    usage: &serde_json::Value,
+) -> Option<(
+    u32,
+    Option<String>,
+    u32,
+    Option<String>,
+    u32,
+    Option<String>,
+    u32,
+    Option<String>,
+)> {
     let five = usage
         .get("five_hour")
         .and_then(|o| o.get("utilization"))

--- a/src/api/misc.rs
+++ b/src/api/misc.rs
@@ -19,9 +19,9 @@ use super::error::ApiError;
 use crate::{
     VERSION_INFO,
     claude_code_state::ClaudeCodeState,
+    claude_web_state::ClaudeWebState,
     config::{CLEWDR_CONFIG, CookieStatus},
     services::cookie_actor::CookieActorHandle,
-    claude_web_state::ClaudeWebState,
 };
 
 /// Cache entry for cookie status responses
@@ -331,7 +331,7 @@ pub async fn api_get_models() -> Json<Value> {
 // ------------------------------
 // Ephemeral org usage enrichment
 // ------------------------------
-use futures::{StreamExt, stream};
+use futures::{StreamExt, TryFutureExt, stream};
 use http::HeaderValue;
 
 async fn augment_utilization(cookies: Vec<CookieStatus>, handle: CookieActorHandle) -> Vec<Value> {
@@ -384,27 +384,26 @@ async fn fetch_usage_percent(
     u32,
     Option<String>,
 )> {
-    // 1) Try OAuth endpoint (works for Pro / Max with Claude Code Access)
-    let usage = match try_oauth_usage(&cookie, &handle).await {
-        Some(u) => u,
-        None => {
-            // 2) Fallback to claude.ai web endpoint (works for Enterprise)
+    let oauth_handle = handle.clone();
+    let fallback_cookie = cookie.clone();
+    let fallback_cookie_name = fallback_cookie.cookie.to_string();
+    let usage = try_oauth_usage(&cookie, &oauth_handle)
+        .or_else(|_| async move {
             info!(
                 "OAuth usage unavailable for {}, trying web fallback",
-                cookie.cookie
+                fallback_cookie_name
             );
-            match ClaudeWebState::fetch_web_usage(handle, cookie.clone()).await {
-                Some(u) => u,
-                None => {
+            ClaudeWebState::fetch_web_usage(handle, fallback_cookie)
+                .await
+                .ok_or_else(|| {
                     warn!(
                         "Web usage fallback also failed for {}",
-                        cookie.cookie
+                        fallback_cookie_name
                     );
-                    return None;
-                }
-            }
-        }
-    };
+                })
+        })
+        .await
+        .ok()?;
 
     extract_usage_fields(&usage)
 }
@@ -413,29 +412,18 @@ async fn fetch_usage_percent(
 async fn try_oauth_usage(
     cookie: &CookieStatus,
     handle: &CookieActorHandle,
-) -> Option<serde_json::Value> {
-    let mut state = match ClaudeCodeState::from_cookie(handle.clone(), cookie.clone()) {
-        Ok(s) => s,
-        Err(e) => {
-            warn!(
-                "try_oauth_usage: from_cookie failed for {}: {}",
-                cookie.cookie, e
-            );
-            return None;
-        }
+) -> Result<serde_json::Value, ()> {
+    let Ok(mut state) = ClaudeCodeState::from_cookie(handle.clone(), cookie.clone()) else {
+        warn!("try_oauth_usage: from_cookie failed for {}", cookie.cookie);
+        return Err(());
     };
     let result = state.fetch_usage_metrics().await;
     state.return_cookie(None).await;
-    match result {
-        Ok(u) => Some(u),
-        Err(e) => {
-            warn!(
-                "try_oauth_usage: fetch failed for {}: {}",
-                cookie.cookie, e
-            );
-            None
-        }
-    }
+    result
+        .inspect_err(|e| {
+            warn!("try_oauth_usage: fetch failed for {}: {}", cookie.cookie, e);
+        })
+        .map_err(|_| ())
 }
 
 /// Extract the eight usage fields from the usage JSON returned by either endpoint

--- a/src/api/misc.rs
+++ b/src/api/misc.rs
@@ -383,9 +383,29 @@ async fn fetch_usage_percent(
     u32,
     Option<String>,
 )> {
-    let mut state = ClaudeCodeState::from_cookie(handle, cookie).ok()?;
-    let usage = state.fetch_usage_metrics().await.ok()?;
+    let mut state = match ClaudeCodeState::from_cookie(handle, cookie.clone()) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                "fetch_usage_percent: from_cookie failed for {}: {}",
+                cookie.cookie, e
+            );
+            return None;
+        }
+    };
+    let usage = match state.fetch_usage_metrics().await {
+        Ok(u) => u,
+        Err(e) => {
+            warn!(
+                "fetch_usage_percent: fetch_usage_metrics failed for {}: {}",
+                cookie.cookie, e
+            );
+            state.return_cookie(None).await;
+            return None;
+        }
+    };
     state.return_cookie(None).await;
+
     let five = usage
         .get("five_hour")
         .and_then(|o| o.get("utilization"))

--- a/src/claude_web_state/mod.rs
+++ b/src/claude_web_state/mod.rs
@@ -1,9 +1,7 @@
 use std::sync::LazyLock;
 
-use axum::http::{
-    HeaderValue,
-    header::COOKIE,
-};
+use axum::http::{HeaderValue, header::COOKIE};
+use serde_json::Value;
 use snafu::ResultExt;
 use tracing::{debug, error, warn};
 use url::Url;
@@ -12,7 +10,6 @@ use wreq::{
     header::{ORIGIN, REFERER},
 };
 use wreq_util::Emulation;
-use serde_json::Value;
 
 use crate::{
     config::{CLAUDE_ENDPOINT, CLEWDR_CONFIG, CookieStatus, Reason},
@@ -79,6 +76,16 @@ impl ClaudeWebState {
         self
     }
 
+    fn build_client(proxy: Option<&Proxy>) -> Result<Client, wreq::Error> {
+        let mut client = Client::builder()
+            .cookie_store(true)
+            .emulation(Emulation::Chrome136);
+        if let Some(proxy) = proxy {
+            client = client.proxy(proxy.to_owned());
+        }
+        client.build()
+    }
+
     /// Build a request with the current cookie and proxy settings
     pub fn build_request(&self, method: Method, url: impl ToString) -> RequestBuilder {
         // let r = SUPER_CLIENT.cloned();
@@ -127,13 +134,7 @@ impl ClaudeWebState {
         // Always pull latest proxy/endpoint before building the client
         self.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
         self.endpoint = CLEWDR_CONFIG.load().endpoint();
-        let mut client = Client::builder()
-            .cookie_store(true)
-            .emulation(Emulation::Chrome136);
-        if let Some(ref proxy) = self.proxy {
-            client = client.proxy(proxy.to_owned());
-        }
-        self.client = client.build().context(WreqSnafu {
+        self.client = Self::build_client(self.proxy.as_ref()).context(WreqSnafu {
             msg: "Failed to build client with new cookie",
         })?;
         self.cookie_header_value = HeaderValue::from_str(res.cookie.to_string().as_str())?;
@@ -215,21 +216,12 @@ impl ClaudeWebState {
 
     /// Fetch usage data via the claude.ai web endpoint.
     /// Used as a fallback when the OAuth usage endpoint is not available (e.g. Without Claude Code Access).
-    pub async fn fetch_web_usage(
-        handle: CookieActorHandle,
-        cookie: CookieStatus,
-    ) -> Option<Value> {
+    pub async fn fetch_web_usage(handle: CookieActorHandle, cookie: CookieStatus) -> Option<Value> {
         let mut state = ClaudeWebState::new(handle);
         state.cookie = Some(cookie.clone());
         state.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
         state.endpoint = CLEWDR_CONFIG.load().endpoint();
-        let mut client = Client::builder()
-            .cookie_store(true)
-            .emulation(Emulation::Chrome136);
-        if let Some(ref proxy) = state.proxy {
-            client = client.proxy(proxy.to_owned());
-        }
-        state.client = client.build().ok()?;
+        state.client = Self::build_client(state.proxy.as_ref()).ok()?;
         state.cookie_header_value =
             HeaderValue::from_str(cookie.cookie.to_string().as_str()).ok()?;
 
@@ -252,7 +244,10 @@ impl ClaudeWebState {
             .send()
             .await
             .inspect_err(|e| {
-                warn!("fetch_web_usage: request failed for {}: {}", cookie.cookie, e);
+                warn!(
+                    "fetch_web_usage: request failed for {}: {}",
+                    cookie.cookie, e
+                );
             })
             .ok()?;
 

--- a/src/claude_web_state/mod.rs
+++ b/src/claude_web_state/mod.rs
@@ -12,6 +12,7 @@ use wreq::{
     header::{ORIGIN, REFERER},
 };
 use wreq_util::Emulation;
+use serde_json::Value;
 
 use crate::{
     config::{CLAUDE_ENDPOINT, CLEWDR_CONFIG, CookieStatus, Reason},
@@ -210,5 +211,56 @@ impl ClaudeWebState {
                 msg: "Failed to delete chat conversation",
             });
         Ok(())
+    }
+
+    /// Fetch usage data via the claude.ai web endpoint.
+    /// Used as a fallback when the OAuth usage endpoint is not available (e.g. Without Claude Code Access).
+    pub async fn fetch_web_usage(
+        handle: CookieActorHandle,
+        cookie: CookieStatus,
+    ) -> Option<Value> {
+        let mut state = ClaudeWebState::new(handle);
+        state.cookie = Some(cookie.clone());
+        state.proxy = CLEWDR_CONFIG.load().wreq_proxy.to_owned();
+        state.endpoint = CLEWDR_CONFIG.load().endpoint();
+        let mut client = Client::builder()
+            .cookie_store(true)
+            .emulation(Emulation::Chrome136);
+        if let Some(ref proxy) = state.proxy {
+            client = client.proxy(proxy.to_owned());
+        }
+        state.client = client.build().ok()?;
+        state.cookie_header_value =
+            HeaderValue::from_str(cookie.cookie.to_string().as_str()).ok()?;
+
+        if let Err(e) = state.bootstrap().await {
+            warn!(
+                "fetch_web_usage: bootstrap failed for {}: {}",
+                cookie.cookie, e
+            );
+            return None;
+        }
+
+        let org_uuid = state.org_uuid.as_ref()?;
+        let url = state
+            .endpoint
+            .join(&format!("api/organizations/{}/usage", org_uuid))
+            .ok()?;
+
+        let res = state
+            .build_request(Method::GET, url)
+            .send()
+            .await
+            .inspect_err(|e| {
+                warn!("fetch_web_usage: request failed for {}: {}", cookie.cookie, e);
+            })
+            .ok()?;
+
+        res.json::<Value>()
+            .await
+            .inspect_err(|e| {
+                warn!("fetch_web_usage: parse failed for {}: {}", cookie.cookie, e);
+            })
+            .ok()
     }
 }


### PR DESCRIPTION
## Problem

Accounts without Claude Code access (e.g. Enterprise, or any subscription lacking the Claude Code entitlement) return `403 Forbidden` ("Claude Code requires a Pro or Max subscription") when fetching usage metrics from the OAuth endpoint (`api.anthropic.com/api/oauth/usage`). This causes the WebUI to show no utilization data for these cookies, even though the data is available via the claude.ai web endpoint.

## Solution

- Add `fetch_web_usage()` method to `ClaudeWebState` that bootstraps a web session and fetches usage from `claude.ai/api/organizations/{org_uuid}/usage`
- Refactor `fetch_usage_percent()` to first attempt the OAuth endpoint, then automatically fall back to the web endpoint on failure
- Extract shared usage JSON parsing into `extract_usage_fields()` helper (both endpoints return the same JSON structure)
- Replace silent `.ok()?` calls with explicit `match` + `warn!` logging for better debuggability

## How it works

1. Try OAuth endpoint (works for accounts with Claude Code access)
2. If that fails, fall back to claude.ai web endpoint via `ClaudeWebState` (works for all accounts with a valid session cookie)
3. Parse the usage response with the shared helper

Both endpoints return the same JSON shape (`five_hour`, `seven_day`, `seven_day_opus`, `seven_day_sonnet`), so no additional parsing logic is needed.