### PR TITLE
feat: Use native incognito mode (`is_temporary`) for non-preserved chats

### DIFF
--- a/src/claude_web_state/chat.rs
+++ b/src/claude_web_state/chat.rs
@@ -111,12 +111,27 @@ impl ClaudeWebState {
                 org_uuid
             ))
             .expect("Url parse error");
+        let is_temporary = !CLEWDR_CONFIG.load().preserve_chats;
         let body = json!({
             "uuid": new_uuid,
-            "name": format!("ClewdR-{}", chrono::Utc::now().format("%Y-%m-%d %H:%M:%S")),
+            "name": if is_temporary { "".to_string() } else { format!("ClewdR-{}", chrono::Utc::now().format("%Y-%m-%d %H:%M:%S")) },
+            "is_temporary": is_temporary,
         });
 
+        let referer = if is_temporary {
+            self.endpoint
+                .join("new?incognito")
+                .map(|u| u.to_string())
+                .unwrap_or_else(|_| format!("{}new?incognito", crate::config::CLAUDE_ENDPOINT))
+        } else {
+            self.endpoint
+                .join("new")
+                .map(|u| u.to_string())
+                .unwrap_or_else(|_| format!("{}new", crate::config::CLAUDE_ENDPOINT))
+        };
+
         self.build_request(Method::POST, endpoint)
+            .header(wreq::header::REFERER, referer)
             .json(&body)
             .send()
             .await

--- a/src/claude_web_state/chat.rs
+++ b/src/claude_web_state/chat.rs
@@ -2,7 +2,7 @@ use colored::Colorize;
 use futures::TryFutureExt;
 use serde_json::json;
 use snafu::ResultExt;
-use tracing::{Instrument, debug, error, info, info_span, warn};
+use tracing::{Instrument, debug, error, info, info_span};
 use wreq::{Method, Response, header::ACCEPT};
 
 use super::ClaudeWebState;
@@ -52,16 +52,9 @@ impl ClaudeWebState {
 
             match transform_res.await {
                 Ok(b) => {
-                    if let Err(e) = state.clean_chat().await {
-                        warn!("Failed to clean chat: {}", e);
-                    }
                     return Ok(b);
                 }
                 Err(e) => {
-                    // delete chat after an error
-                    if let Err(e) = state.clean_chat().await {
-                        warn!("Failed to clean chat: {}", e);
-                    }
                     error!("{e}");
                     // 429 error
                     if let ClewdrError::InvalidCookie { reason } = e {

--- a/src/claude_web_state/mod.rs
+++ b/src/claude_web_state/mod.rs
@@ -185,30 +185,6 @@ impl ClaudeWebState {
     /// Deletes or renames the current chat conversation based on configuration
     /// If preserve_chats is true, the chat is renamed rather than deleted
     pub async fn clean_chat(&self) -> Result<(), ClewdrError> {
-        if CLEWDR_CONFIG.load().preserve_chats {
-            return Ok(());
-        }
-        let Some(ref org_uuid) = self.org_uuid else {
-            return Ok(());
-        };
-        let Some(ref conv_uuid) = self.conv_uuid else {
-            return Ok(());
-        };
-        let endpoint = self
-            .endpoint
-            .join(&format!(
-                "api/organizations/{}/chat_conversations/{}",
-                org_uuid, conv_uuid
-            ))
-            .expect("Url parse error");
-        debug!("Deleting chat: {}", conv_uuid);
-        let _ = self
-            .build_request(Method::DELETE, endpoint)
-            .send()
-            .await
-            .context(WreqSnafu {
-                msg: "Failed to delete chat conversation",
-            });
         Ok(())
     }
 }

--- a/src/claude_web_state/mod.rs
+++ b/src/claude_web_state/mod.rs
@@ -5,7 +5,7 @@ use axum::http::{
     header::COOKIE,
 };
 use snafu::ResultExt;
-use tracing::{debug, error, warn};
+use tracing::{error, warn};
 use url::Url;
 use wreq::{
     Client, Method, Proxy, RequestBuilder,
@@ -180,11 +180,5 @@ impl ClaudeWebState {
                 warn!("Failed to persist usage statistics: {}", err);
             }
         }
-    }
-
-    /// Deletes or renames the current chat conversation based on configuration
-    /// If preserve_chats is true, the chat is renamed rather than deleted
-    pub async fn clean_chat(&self) -> Result<(), ClewdrError> {
-        Ok(())
     }
 }


### PR DESCRIPTION
## Use native incognito mode (`is_temporary`) for non-preserved chats

### Summary

When `preserve_chats` is disabled, conversations are now created with `is_temporary: true`, leveraging Claude.ai's native incognito mode instead of the previous create-then-delete approach.

### Changes

- **`chat.rs` — `send_chat()`**:
  - Set `is_temporary: true` when `preserve_chats = false`, matching Claude.ai's native incognito behavior.
  - Use an empty name for temporary conversations instead of the `ClewdR-{timestamp}` prefix.
  - Set the `Referer` header to `new?incognito` for the conversation creation request when in incognito mode.

- **`mod.rs` — `clean_chat()`**:
  - Skip the DELETE request for temporary (incognito) conversations, as the server handles their cleanup automatically. This removes an unnecessary network round-trip on every request when `preserve_chats = false`.

### Motivation

Previously, non-preserved conversations were created as regular chats and explicitly deleted after completion. This had a few downsides:

1. The conversation briefly appeared in the user's chat history before deletion.
2. An extra DELETE request was required for every single conversation.
3. It did not match how Claude.ai's own incognito mode works.

By passing `is_temporary: true` during conversation creation, the server treats it as an incognito session natively — the conversation never enters persistent history in the first place.