### PR TITLE
Preserve thinking.display field when streaming to display thinking for newer opus models

### DIFF
--- a/src/types/claude.rs
+++ b/src/types/claude.rs
@@ -154,14 +154,24 @@ impl CreateMessageParams {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Thinking {
-    Enabled { budget_tokens: u64 },
+    Enabled {
+        budget_tokens: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display: Option<String>,
+    },
     Disabled,
-    Adaptive,
+    Adaptive {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display: Option<String>,
+    },
 }
 
 impl Thinking {
     pub fn new(budget_tokens: u64) -> Self {
-        Self::Enabled { budget_tokens }
+        Self::Enabled {
+            budget_tokens,
+            display: None,
+        }
     }
 }
 

--- a/src/types/claude.rs
+++ b/src/types/claude.rs
@@ -154,11 +154,7 @@ impl CreateMessageParams {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Thinking {
-    Enabled {
-        budget_tokens: u64,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        display: Option<String>,
-    },
+    Enabled { budget_tokens: u64 },
     Disabled,
     Adaptive {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -168,10 +164,7 @@ pub enum Thinking {
 
 impl Thinking {
     pub fn new(budget_tokens: u64) -> Self {
-        Self::Enabled {
-            budget_tokens,
-            display: None,
-        }
+        Self::Enabled { budget_tokens }
     }
 }
 


### PR DESCRIPTION
Add an optional display field to Adaptive variants of the Thinking enum so the value survives the deserialize -> serialize round trip.

Previously clewdr silently dropped `{"display":"summarized"}`, so newer models fell back to encrypted thinking on the `/code/v1` surface.

The field uses `#[serde(default, skip_serializing_if = "Option::is_none")]` so clients sending a bare `{"type":"adaptive"}` are unaffected.

E2E tested.