### PR TITLE
fix(oai): convert Claude tool_use to OpenAI tool_calls (stream + non-stream)

### DIFF
--- a/src/middleware/claude/claude2oai.rs
+++ b/src/middleware/claude/claude2oai.rs
@@ -3,7 +3,7 @@ use futures::{Stream, TryStreamExt};
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::types::claude::{ContentBlockDelta, CreateMessageResponse, StreamEvent};
+use crate::types::claude::{ContentBlock, ContentBlockDelta, CreateMessageResponse, StreamEvent};
 
 /// Represents the data structure for streaming events in OpenAI API format
 /// Contains a choices array with deltas of content
@@ -56,6 +56,48 @@ pub fn build_event(content: EventContent) -> Event {
     event.json_data(data).unwrap()
 }
 
+/// Builds an OpenAI-compatible SSE event carrying a streamed `tool_call` delta.
+///
+/// `id`/`name` are sent only on the opening chunk (from `content_block_start`);
+/// subsequent chunks stream the JSON `arguments` fragment from `input_json_delta`.
+fn build_tool_event(index: usize, id: Option<String>, name: Option<String>, arguments: &str) -> Event {
+    let mut function = serde_json::json!({ "arguments": arguments });
+    if let Some(name) = name {
+        function["name"] = Value::String(name);
+    }
+    let mut tool_call = serde_json::json!({
+        "index": index,
+        "function": function,
+    });
+    if let Some(id) = id {
+        tool_call["id"] = Value::String(id);
+        tool_call["type"] = Value::String("function".to_string());
+    }
+    let data = serde_json::json!({
+        "choices": [{
+            "index": 0,
+            "delta": { "tool_calls": [tool_call] }
+        }]
+    });
+    Event::default().json_data(data).unwrap()
+}
+
+/// Builds the terminating OpenAI SSE chunk carrying `finish_reason`.
+///
+/// OpenAI clients rely on a final `finish_reason: "tool_calls"` chunk to know the
+/// streamed tool call is complete and should be executed; Claude signals this via
+/// `message_delta` with `stop_reason: "tool_use"`.
+fn build_finish_event(reason: &str) -> Event {
+    let data = serde_json::json!({
+        "choices": [{
+            "index": 0,
+            "delta": {},
+            "finish_reason": reason
+        }]
+    });
+    Event::default().json_data(data).unwrap()
+}
+
 /// Transforms a Claude.ai event stream into an OpenAI-compatible event stream
 ///
 /// Extracts content from Claude events and reformats them to match OpenAI's streaming format.
@@ -75,23 +117,62 @@ pub fn transform_stream<I, E>(s: I) -> impl Stream<Item = Result<Event, E>>
 where
     I: Stream<Item = Result<eventsource_stream::Event, E>>,
 {
-    s.try_filter_map(async |eventsource_stream::Event { data, .. }| {
-        let Ok(parsed) = serde_json::from_str::<StreamEvent>(&data) else {
-            return Ok(None);
-        };
-        let StreamEvent::ContentBlockDelta { delta, .. } = parsed else {
-            return Ok(None);
-        };
-        match delta {
-            ContentBlockDelta::TextDelta { text } => {
-                Ok(Some(build_event(EventContent::Content { content: text })))
+    // Maps a Claude content-block index to a sequential OpenAI tool_call index,
+    // so parallel tool calls keep stable, gap-free indices in the OpenAI stream.
+    let tool_index = std::sync::Arc::new(std::sync::Mutex::new(
+        std::collections::HashMap::<usize, usize>::new(),
+    ));
+    s.try_filter_map(move |eventsource_stream::Event { data, .. }| {
+        let tool_index = tool_index.clone();
+        async move {
+            let Ok(parsed) = serde_json::from_str::<StreamEvent>(&data) else {
+                return Ok(None);
+            };
+            match parsed {
+                StreamEvent::ContentBlockStart {
+                    index,
+                    content_block: ContentBlock::ToolUse { id, name, .. },
+                } => {
+                    let oai_index = {
+                        let mut map = tool_index.lock().unwrap();
+                        let next = map.len();
+                        *map.entry(index).or_insert(next)
+                    };
+                    Ok(Some(build_tool_event(oai_index, Some(id), Some(name), "")))
+                }
+                StreamEvent::ContentBlockDelta { index, delta } => match delta {
+                    ContentBlockDelta::TextDelta { text } => {
+                        Ok(Some(build_event(EventContent::Content { content: text })))
+                    }
+                    ContentBlockDelta::ThinkingDelta { thinking } => {
+                        Ok(Some(build_event(EventContent::Reasoning {
+                            reasoning_content: thinking,
+                        })))
+                    }
+                    ContentBlockDelta::InputJsonDelta { partial_json } => {
+                        let oai_index = tool_index.lock().unwrap().get(&index).copied();
+                        match oai_index {
+                            Some(oai_index) => Ok(Some(build_tool_event(
+                                oai_index,
+                                None,
+                                None,
+                                &partial_json,
+                            ))),
+                            None => Ok(None),
+                        }
+                    }
+                    _ => Ok(None),
+                },
+                StreamEvent::MessageDelta { delta, .. }
+                    if matches!(
+                        delta.stop_reason,
+                        Some(crate::types::claude::StopReason::ToolUse)
+                    ) =>
+                {
+                    Ok(Some(build_finish_event("tool_calls")))
+                }
+                _ => Ok(None),
             }
-            ContentBlockDelta::ThinkingDelta { thinking } => {
-                Ok(Some(build_event(EventContent::Reasoning {
-                    reasoning_content: thinking,
-                })))
-            }
-            _ => Ok(None),
         }
     })
 }
@@ -105,6 +186,24 @@ pub fn transforms_json(input: CreateMessageResponse) -> Value {
             _ => None,
         })
         .collect::<String>();
+
+    let tool_calls = input
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            crate::types::claude::ContentBlock::ToolUse {
+                id, name, input: args, ..
+            } => Some(serde_json::json!({
+                "id": id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": serde_json::to_string(args).unwrap_or_else(|_| "{}".to_string()),
+                }
+            })),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
 
     let usage = input.usage.as_ref().map(|u| {
         serde_json::json!({
@@ -125,6 +224,14 @@ pub fn transforms_json(input: CreateMessageResponse) -> Value {
         None => "stop",
     };
 
+    let mut message = serde_json::json!({
+        "role": "assistant",
+        "content": content
+    });
+    if !tool_calls.is_empty() {
+        message["tool_calls"] = Value::Array(tool_calls);
+    }
+
     serde_json::json!({
         "id": input.id,
         "object": "chat.completion",
@@ -135,12 +242,70 @@ pub fn transforms_json(input: CreateMessageResponse) -> Value {
         "model": input.model,
         "choices": [{
             "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": content
-            },
+            "message": message,
             "finish_reason": finish_reason
         }],
         "usage": usage
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::claude::CreateMessageResponse;
+
+    #[test]
+    fn tool_use_block_becomes_oai_tool_calls() {
+        let json = r#"{
+            "content": [
+                {"type": "text", "text": "<content>scanning</content>"},
+                {"type": "tool_use", "id": "toolu_1", "name": "read_file", "input": {"path": "a.txt"}}
+            ],
+            "id": "msg_1",
+            "model": "claude-opus-4-8",
+            "role": "assistant",
+            "stop_reason": "tool_use",
+            "stop_sequence": null,
+            "type": "message",
+            "usage": null
+        }"#;
+        let resp: CreateMessageResponse = serde_json::from_str(json).unwrap();
+        let out = transforms_json(resp);
+
+        let msg = &out["choices"][0]["message"];
+        assert_eq!(out["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(msg["content"], "<content>scanning</content>");
+
+        let tc = &msg["tool_calls"][0];
+        assert_eq!(tc["id"], "toolu_1");
+        assert_eq!(tc["type"], "function");
+        assert_eq!(tc["function"]["name"], "read_file");
+        // arguments must be a JSON *string*, not an object
+        let args = tc["function"]["arguments"]
+            .as_str()
+            .expect("arguments must be a string");
+        assert!(args.contains("a.txt"), "arguments missing payload: {args}");
+    }
+
+    #[test]
+    fn plain_text_response_has_no_tool_calls_field() {
+        let json = r#"{
+            "content": [{"type": "text", "text": "hi"}],
+            "id": "msg_2",
+            "model": "claude-opus-4-8",
+            "role": "assistant",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "type": "message",
+            "usage": null
+        }"#;
+        let resp: CreateMessageResponse = serde_json::from_str(json).unwrap();
+        let out = transforms_json(resp);
+
+        assert_eq!(out["choices"][0]["finish_reason"], "stop");
+        assert!(
+            out["choices"][0]["message"].get("tool_calls").is_none(),
+            "plain text response must not carry a tool_calls field"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

On the OpenAI-compatible endpoints (`/v1/chat/completions` and `/code/v1/chat/completions`), tool calls never reach the client. The response carries `finish_reason: "tool_calls"` but the `tool_calls` field is absent, so clients (e.g. SillyTavern) receive an assistant message that *claims* it will call a tool yet contains no actual call — tools silently never fire.

## Root cause

`src/middleware/claude/claude2oai.rs` only handled `text`/`thinking` blocks when converting Claude responses to OpenAI format; `tool_use` was dropped:

- **Non-stream** (`transforms_json`): collected only `ContentBlock::Text` into `content` (`_ => None`) and never emitted a `tool_calls` array, while still mapping `stop_reason: tool_use` → `finish_reason: "tool_calls"`.
- **Stream** (`transform_stream`): forwarded only `TextDelta`/`ThinkingDelta`; `content_block_start` for `tool_use` and `input_json_delta` were ignored, and no terminating `finish_reason` chunk was sent.

So the client is told a tool was called but never receives the call.

## Fix

- **Non-stream**: collect `tool_use` blocks into an OpenAI `tool_calls` array (`{id, type: "function", function: {name, arguments}}`, with `arguments` JSON-stringified), attached only when present.
- **Stream**: emit OpenAI tool_call deltas — an opener (`id`/`name`/`type`) from `content_block_start`, argument fragments from `input_json_delta` (Claude content-block index mapped to a sequential, gap-free tool_call index so parallel calls stay correct), and a terminating `finish_reason: "tool_calls"` chunk from `message_delta` (`stop_reason: tool_use`).
- Plain-text responses are unchanged (no spurious `tool_calls` field); text/thinking streaming is unaffected.

Both OpenAI-compatible endpoints share `to_oai`, so this covers Claude.ai and Claude Code alike.

## Verification

Unit tests for the non-stream conversion (tool_use → tool_calls; plain text → no `tool_calls` field).

Live streaming test against a real Claude Code response (`stream: true`, one tool):

```
data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"","name":"get_weather"},"id":"toolu_...","index":0,"type":"function"}]},"index":0}]}
data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{\"ci"},"index":0}]},"index":0}]}
data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"ty\": \"Tokyo\"}"},"index":0}]},"index":0}]}
data: {"choices":[{"delta":{},"finish_reason":"tool_calls","index":0}]}
```

The argument deltas reassemble to `{"city": "Tokyo"}` and the stream terminates with `finish_reason: "tool_calls"`.
