### PR TITLE
Pass through Claude beta headers

### DIFF
--- a/src/claude_code_state/chat.rs
+++ b/src/claude_code_state/chat.rs
@@ -22,6 +22,22 @@ pub(super) const CLAUDE_BETA_BASE: &str = "oauth-2025-04-20";
 const CLAUDE_USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
 pub(super) const CLAUDE_API_VERSION: &str = "2023-06-01";
 
+fn claude_beta_header(client_beta: Option<&str>) -> String {
+    let mut betas = vec![CLAUDE_BETA_BASE];
+    if let Some(client_beta) = client_beta {
+        for beta in client_beta
+            .split(',')
+            .map(str::trim)
+            .filter(|beta| !beta.is_empty())
+        {
+            if !betas.contains(&beta) {
+                betas.push(beta);
+            }
+        }
+    }
+    betas.join(",")
+}
+
 impl ClaudeCodeState {
     /// Attempts to send a chat message to Claude API with retry mechanism
     ///
@@ -144,7 +160,10 @@ impl ClaudeCodeState {
             )
             .bearer_auth(access_token)
             .header(USER_AGENT, CLAUDE_CODE_USER_AGENT)
-            .header("anthropic-beta", CLAUDE_BETA_BASE)
+            .header(
+                "anthropic-beta",
+                claude_beta_header(self.anthropic_beta.as_deref()),
+            )
             .header("anthropic-version", CLAUDE_API_VERSION)
             .json(body)
             .send()
@@ -478,7 +497,10 @@ impl ClaudeCodeState {
             )
             .bearer_auth(access_token)
             .header(USER_AGENT, CLAUDE_CODE_USER_AGENT)
-            .header("anthropic-beta", CLAUDE_BETA_BASE)
+            .header(
+                "anthropic-beta",
+                claude_beta_header(self.anthropic_beta.as_deref()),
+            )
             .header("anthropic-version", CLAUDE_API_VERSION)
             .json(body)
             .send()

--- a/src/claude_code_state/mod.rs
+++ b/src/claude_code_state/mod.rs
@@ -30,6 +30,7 @@ pub struct ClaudeCodeState {
     pub api_format: ClaudeApiFormat,
     pub stream: bool,
     pub system_prompt_hash: Option<u64>,
+    pub anthropic_beta: Option<String>,
     pub usage: Usage,
 }
 
@@ -46,6 +47,7 @@ impl ClaudeCodeState {
             api_format: ClaudeApiFormat::Claude,
             stream: false,
             system_prompt_hash: None,
+            anthropic_beta: None,
             usage: Usage::default(),
         }
     }

--- a/src/middleware/claude/mod.rs
+++ b/src/middleware/claude/mod.rs
@@ -73,6 +73,14 @@ impl ClaudeContext {
     }
 
     #[must_use]
+    pub fn anthropic_beta(&self) -> Option<&str> {
+        match self {
+            ClaudeContext::Web(_) => None,
+            ClaudeContext::Code(ctx) => ctx.anthropic_beta.as_deref(),
+        }
+    }
+
+    #[must_use]
     pub fn usage(&self) -> &Usage {
         match self {
             ClaudeContext::Web(ctx) => &ctx.usage,

--- a/src/middleware/claude/request.rs
+++ b/src/middleware/claude/request.rs
@@ -311,6 +311,8 @@ pub struct ClaudeCodeContext {
     pub(super) api_format: ClaudeApiFormat,
     /// The hash of the system messages for caching purposes
     pub(super) system_prompt_hash: Option<u64>,
+    /// Client-supplied Anthropic beta tokens to forward upstream
+    pub(super) anthropic_beta: Option<String>,
     // Usage information for the request
     pub(super) usage: Usage,
 }
@@ -324,6 +326,11 @@ where
     type Rejection = ClewdrError;
 
     async fn from_request(req: Request, _: &S) -> Result<Self, Self::Rejection> {
+        let anthropic_beta = req
+            .headers()
+            .get("anthropic-beta")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
         let NormalizeRequest(mut body, format) = NormalizeRequest::from_request(req, &()).await?;
 
         // Check for test messages and respond appropriately
@@ -378,6 +385,7 @@ where
             stream,
             api_format: format,
             system_prompt_hash,
+            anthropic_beta,
             usage: Usage {
                 input_tokens,
                 output_tokens: 0, // Placeholder for output token count

--- a/src/providers/claude/mod.rs
+++ b/src/providers/claude/mod.rs
@@ -166,6 +166,7 @@ impl LLMProvider for ClaudeCodeProvider {
         state.api_format = request.context.api_format();
         state.stream = request.context.is_stream();
         state.system_prompt_hash = request.context.system_prompt_hash();
+        state.anthropic_beta = request.context.anthropic_beta().map(str::to_owned);
         state.usage = request.context.usage().to_owned();
         let ClaudeInvocation {
             params,


### PR DESCRIPTION
## What changed

- Preserve `context_management` in Claude Code request bodies.
- Forward the downstream `anthropic-beta` header to Claude Code Messages and count-tokens requests.
- Keep the required `oauth-2025-04-20` beta first and de-duplicate beta tokens.

## Why

The earlier workaround removed `context_management`, preventing supported context-management features from reaching Anthropic. Clients already send the beta that matches the feature they use, so clewdr now preserves that header instead of inferring beta tokens from the request body.

## Validation

- `cargo xtask lint`
- Claude Code state tests (`24 passed`)
- `git diff --check`

No new tests were added.
